### PR TITLE
Implement Key.get properly

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -5,5 +5,5 @@ eval `opam config env`
 opam install mirage --yes
 opam source mirage-skeleton
 cd mirage-skeleton.dev
-MODE=unix make
-MODE=xen  make
+MODE=unix make && make clean
+MODE=xen  make && make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ env:
   - PACKAGE=functoria
   - PINS="mirage:https://github.com/Drup/mirage.git#functhulhu mirage-skeleton.dev:https://github.com/Drup/mirage-skeleton.git#functoria"
   matrix:
-  - OCAML_VERSION=4.01
-  - OCAML_VERSION=4.02
+  - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.01
+  - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02

--- a/src/functoria.ml
+++ b/src/functoria.ml
@@ -490,6 +490,9 @@ module Make (P:SPECIALIZED) = struct
       | Some s -> with_file s f
     in R.ok @@ with_fmt f
 
+  let show_keys keymap keyset =
+    info "%a %a" blue "Keys:" (Key.pp_map keymap) keyset
+
   (* Compile the configuration file and attempt to dynlink it.
    * It is responsible for registering an application via
    * [register] in order to have an observable
@@ -568,10 +571,13 @@ module Make (P:SPECIALIZED) = struct
     let describe map t =
       describe ~map t
 
-    let eval map t =
-      let info = Config.eval map t in
+    let eval switch_map t =
+      let info = Config.eval switch_map t in
       let keys = Key.term ~stage:`Configure (Key.deps info) in
-      let f map = Key.eval map info @@ map in
+      let f map =
+        show_keys map @@ Key.deps info ;
+        Key.eval map info @@ map
+      in
       Cmdliner.Term.(pure f $ keys)
   end
 

--- a/src/functoria.ml
+++ b/src/functoria.ml
@@ -59,7 +59,7 @@ module Devices = struct
     Codegen.newline fmt;
     let bootvars = Info.keys i in
     Fmt.pf fmt "@[<v>%a@]@."
-      (Fmt.iter Key.Set.iter @@ Key.emit) bootvars ;
+      (Fmt.iter Key.Set.iter @@ Key.emit @@ Info.keymap i) bootvars ;
     Codegen.append fmt "let runtime_keys = %a"
       Fmt.(Dump.list (fmt "%s_t"))
       (List.map Key.ocaml_name @@
@@ -319,19 +319,18 @@ module Config = struct
     in
     { libraries ; packages ; keys ; name ; root ; jobs }
 
-  let eval { name = n ; root ; packages ; libraries ; keys ; jobs } =
-    let e = G.eval jobs in
+  let eval map_switching { name = n ; root ; packages ; libraries ; keys ; jobs } =
+    let e = G.eval ~map:map_switching jobs in
     let open Key in
     let packages = pure StringSet.union $ packages $ Engine.packages e in
     let libraries = pure StringSet.union $ libraries $ Engine.libraries e in
     let keys = Key.Set.union keys @@ Engine.keys e in
-    let di =
-      pure (fun libraries packages ->
-        Info.create ~libraries ~packages ~keys ~name:n ~root)
+    let di = pure (fun libraries packages keymap ->
+        e, Info.create ~libraries ~packages ~keys ~keymap ~name:n ~root)
       $ libraries
       $ packages
     in
-    e, with_deps ~keys di
+    with_deps ~keys di
 
   (** Extract all the keys directly.
       Useful to pre-resolve the keys provided by the specialized DSL. *)
@@ -341,8 +340,8 @@ module Config = struct
   let name t = t.name
   let keys t = t.keys
 
-  let gen_pp pp ~partial fmt t =
-    pp fmt @@ G.simplify @@ G.eval ~partial t.jobs
+  let gen_pp pp ~partial ~map fmt jobs =
+    pp fmt @@ G.simplify @@ G.eval ~partial ~map jobs
 
   let pp = gen_pp G.pp
   let pp_dot = gen_pp G.pp_dot
@@ -478,18 +477,18 @@ module Make (P:SPECIALIZED) = struct
         root root root ;
     )
 
-  let describe g ~dotcmd ~dot ~eval file =
+  let describe ~dotcmd ~dot ~eval ~output ~map {Config. jobs } =
     let f fmt =
       Config.(if dot then pp_dot else pp)
-        ~partial:(not eval) fmt g
+        ~partial:(not eval) ~map fmt jobs
     in
-    let with_fmt f = match file with
+    let with_fmt f = match output with
       | None when dot ->
         let f oc = with_channel oc f in
         with_process_out dotcmd f
       | None -> f Fmt.stdout
       | Some s -> with_file s f
-    in with_fmt f
+    in R.ok @@ with_fmt f
 
   (* Compile the configuration file and attempt to dynlink it.
    * It is responsible for registering an application via
@@ -537,7 +536,7 @@ module Make (P:SPECIALIZED) = struct
       Key.term ~stage:`Configure @@ Config.extract_keys (P.config [])
 
     type t = Config.t
-    type info = Info.t
+    type evaluated = G.t * Info.t
 
     let load file =
       scan_conf file >>= fun file ->
@@ -552,15 +551,19 @@ module Make (P:SPECIALIZED) = struct
     let switching_keys t =
       Key.term ~stage:`Configure @@ Config.keys t
 
-    let eval t =
-      let evaluated, info = Config.eval t in
-      object
-        method configure info = configure info evaluated
-        method clean info = clean info evaluated
-        method build info = build info
-        method info = Key.term_value ~stage:`Configure info
-        method describe = describe t
-      end
+    let configure (jobs, info) = configure info jobs
+
+    let clean (jobs, info) = clean info jobs
+    let build (_jobs, info) = build info
+
+    let describe map t =
+      describe ~map t
+
+    let eval map t =
+      let info = Config.eval map t in
+      let keys = Key.term ~stage:`Configure (Key.deps info) in
+      let f map = Key.eval map info @@ map in
+      Cmdliner.Term.(pure f $ keys)
   end
 
   let launch () =

--- a/src/functoria.mli
+++ b/src/functoria.mli
@@ -104,6 +104,13 @@ module Make (P : SPECIALIZED) : sig
         @param keys The keys related to this module.
     *)
 
+  val get_base_keymap: unit -> Key.map
+  (** [get_base_keymap ()] returns the keymap containing the keys of the specialized DSL.
+      This functions should be avoided.
+
+      @deprecated Use the regular key mechanism.
+  *)
+
   val launch : unit -> unit
   (** Launch the cmdliner application.
       Should only be used by the host specialized DSL.

--- a/src/functoria_dsl.ml
+++ b/src/functoria_dsl.ml
@@ -23,6 +23,7 @@ module Info = struct
     name: string;
     root: string;
     keys: Key.Set.t;
+    keymap: Functoria_key.map;
     libraries : StringSet.t;
     packages : StringSet.t;
   }
@@ -32,12 +33,14 @@ module Info = struct
   let libraries t = t.libraries
   let packages t = t.packages
   let keys t = t.keys
+  let keymap t = t.keymap
 
   let create
       ?(keys=Key.Set.empty)
       ?(libraries=StringSet.empty) ?(packages=StringSet.empty)
+      ~keymap
       ~name ~root =
-    { name ; root ; keys ; libraries ; packages }
+    { name ; root ; keys ; libraries ; packages ; keymap}
 
 end
 

--- a/src/functoria_dsl.mli
+++ b/src/functoria_dsl.mli
@@ -113,10 +113,14 @@ module Info : sig
   val keys : t -> Key.Set.t
   (** Keys declared by the project. *)
 
+  val keymap : t -> Key.map
+  (** Map from key entered in the command line to values. *)
+
   val create :
     ?keys:Key.Set.t ->
     ?libraries:StringSet.t ->
     ?packages:StringSet.t ->
+    keymap:Key.map ->
     name:string ->
     root:string -> t
 

--- a/src/functoria_graph.mli
+++ b/src/functoria_graph.mli
@@ -54,9 +54,9 @@ val normalize : t -> t
 val simplify : t -> t
 (** [simplify g] simplifies the graph so that it's easier to read for humans. *)
 
-val eval : ?partial:bool -> t -> t
-(** [eval g] will removes all the [If] vertices by
-    trying to resolve the keys. It will then call {!normalize}
+val eval : ?partial:bool -> map:Key.map -> t -> t
+(** [eval ~map g] will removes all the [If] vertices by
+    resolving the keys using [map]. It will then call {!normalize}
 
     If [partial] is [true], then it will only evaluate
     [If] vertices which condition is resolved.

--- a/src/functoria_key.ml
+++ b/src/functoria_key.ml
@@ -224,6 +224,15 @@ let pp fmt k = Fmt.string fmt (name k)
 let pp_deps fmt v =
   Fmt.(iter Set.iter ~sep:(unit ", ") pp) fmt v.deps
 
+let pp_map map =
+  let f fmt (Any k) =
+    let default = if mem map k then Fmt.nop else Fmt.unit " (default)" in
+    Fmt.pf fmt "%a=%a%a"
+      Fmt.(styled `Bold string) k.name
+      (snd k.desc.converter) (get map k)
+      default ()
+  in
+  Fmt.(iter ~sep:(unit ",@ ") Set.iter f)
 
 (** {2 Cmdliner interface} *)
 

--- a/src/functoria_key.mli
+++ b/src/functoria_key.mli
@@ -177,6 +177,9 @@ val eval : map -> 'a value -> 'a
 val get : map -> 'a key -> 'a
 (** [get map k] resolves [k], using default values if necessary. *)
 
+val pp_map : map -> Set.t Fmt.t
+(** [pp_map map fmt set] prints the keys in [set] with the values in [map]. *)
+
 (** {3 Code emission} *)
 
 val ocaml_name : t -> string

--- a/src/functoria_misc.ml
+++ b/src/functoria_misc.ml
@@ -425,3 +425,35 @@ module Terminfo = struct
       else 80
 
 end
+
+module Univ = struct
+
+  type 'a key = string * ('a -> exn) * (exn -> 'a)
+
+  let new_key : string -> 'a key =
+    fun s (type a) ->
+      let module M = struct
+        exception E of a
+      end
+      in
+      ( s
+      , (fun a -> M.E a)
+      , (function M.E a -> a | _ -> assert false)
+      )
+
+  module Map = Map.Make(String)
+
+  type t = exn Map.t
+
+  let empty = Map.empty
+
+  let add (kn, kput, _kget) v t =
+    Map.add kn (kput v) t
+
+  let mem (kn, _, _) t =
+    Map.mem kn t
+
+  let find (kn, _kput, kget) t =
+    if Map.mem kn t then Some (kget @@ Map.find kn t)
+    else None
+end

--- a/src/functoria_misc.mli
+++ b/src/functoria_misc.mli
@@ -171,3 +171,16 @@ end
 module Terminfo: sig
   val columns : unit -> int
 end
+
+(** Universal map *)
+module Univ : sig
+
+  type 'a key
+  val new_key : string -> 'a key
+  type t
+  val empty : t
+  val add : 'a key -> 'a -> t -> t
+  val mem : 'a key -> t -> bool
+  val find : 'a key -> t -> 'a option
+
+end

--- a/src/functoria_sigs.mli
+++ b/src/functoria_sigs.mli
@@ -16,7 +16,6 @@
 
 (** A configuration engine. For internal use. *)
 module type CONFIG = sig
-  type info
 
   val name : string
   (** Name of the project. *)
@@ -29,28 +28,33 @@ module type CONFIG = sig
   type t
   (** A configuration. *)
 
-  val base_keys : unit Cmdliner.Term.t
+  type evaluated
+  (** A configuration resolved against the command line. *)
+
+  val base_keys : Functoria_key.map Cmdliner.Term.t
   (** Base keys provided by the specialized DSL. *)
 
   val load: string option -> (t, string) Rresult.result
   (** Read a config file. If no name is given, search for use
       [config.ml]. *)
 
-  val switching_keys : t -> unit Cmdliner.Term.t
+  val switching_keys : t -> Functoria_key.map Cmdliner.Term.t
 
-  val eval : t -> <
-      build : info -> (unit, string) Rresult.result;
-      clean : info -> (unit, string) Rresult.result;
-      configure :
-        info ->
-        no_opam:bool ->
-        no_depext:bool ->
-        no_opam_version:bool ->
-        (unit, string) Rresult.result;
-      info : info Cmdliner.Term.t;
-      describe :
-        dotcmd:string -> dot:bool -> eval:bool ->
-        string option -> unit;
-    >
+  val configure :
+    evaluated ->
+    no_opam:bool ->
+    no_depext:bool ->
+    no_opam_version:bool ->
+    (unit, string) Rresult.result
+
+  val build : evaluated -> (unit, string) Rresult.result
+  val clean : evaluated -> (unit, string) Rresult.result
+
+  val describe :
+    Functoria_key.map -> t ->
+    dotcmd:string -> dot:bool -> eval:bool -> output:string option ->
+    (unit, string) Rresult.result
+
+  val eval : Functoria_key.map -> t -> evaluated Cmdliner.Term.t
 
 end

--- a/src/functoria_tool.ml
+++ b/src/functoria_tool.ml
@@ -76,7 +76,7 @@ module Make (Config : Functoria_sigs.CONFIG) = struct
         ~doc:"File where to output description or dot representation."
         ["o"; "output"]
     in
-    Arg.(value & opt (some file) None & doc)
+    Arg.(value & opt (some string) None & doc)
 
   let () =
     let i = Terminfo.columns () in

--- a/src/functoria_tool.ml
+++ b/src/functoria_tool.ml
@@ -84,29 +84,31 @@ module Make (Config : Functoria_sigs.CONFIG) = struct
     Format.pp_set_margin Format.err_formatter i ;
     Fmt_tty.setup_std_outputs ()
 
-  let base_keys = Config.base_keys
-
-  let with_config =
-    let config =
-      match Term.eval_peek_opts file with
+  let load_config () =
+    let c = match Term.eval_peek_opts file with
       | _, `Ok config -> config
       | _ -> None
     in
-    let show_error t _ = match t with
+    let _ = Term.eval_peek_opts Config.base_keys in
+    Config.load c
+
+  let config = Lazy.from_fun load_config
+
+  let with_config f options =
+    let show_error t = match t with
       | Ok r -> r
       | Error s -> show_error "%s" s
     in
-    let _  = Term.eval_peek_opts base_keys in
-    let t = lazy (Config.load config) in
-    fun f f_no ->
-      let term = match Lazy.force t with
-        | Ok t ->
-          let pkeys = Config.switching_keys t in
-          let _ = Term.eval_peek_opts pkeys in
-          f @@ Config.eval t
-        | Error err -> f_no err
-      in
-      Term.(pure show_error $ term $ file)
+    let term = match Lazy.force config with
+      | Ok t ->
+        let pkeys = Config.switching_keys t in
+        let term = match Term.eval_peek_opts pkeys with
+          | Some map_switch, _ -> f map_switch t
+          | _, _ -> Term.pure (fun _ -> Error "Error during peeking.")
+        in term
+      | Error err -> Term.pure (fun _ -> Error err)
+    in
+    Term.(pure (fun _ -> show_error) $ file $ (term $ options))
 
 
   (* CONFIGURE *)
@@ -117,16 +119,14 @@ module Make (Config : Functoria_sigs.CONFIG) = struct
       `S "DESCRIPTION";
       `P "The $(b,configure) command initializes a fresh $(mname) application."
     ] in
-    let f t =
-      let configure no_opam no_opam_version no_depext info =
-        t#configure info ~no_opam ~no_depext ~no_opam_version in
-      Term.(pure configure $ no_opam $ no_opam_version_check $ no_depext $ t#info)
+    let options =
+      Term.(pure (fun a b c -> a, b, c) $ no_opam $ no_opam_version_check $ no_depext)
     in
-    let f_no err =
-      let f _ _ _ () = Error err in
-      Term.(pure f $ no_opam $ no_opam_version_check $ no_depext $ base_keys)
+    let configure info (no_opam, no_opam_version, no_depext) =
+      Config.configure info ~no_opam ~no_depext ~no_opam_version
     in
-    with_config f f_no, term_info "configure" ~doc ~man
+    let f map conf = Term.(pure configure $ Config.eval map conf) in
+    with_config f options, term_info "configure" ~doc ~man
 
   (* DESCRIBE *)
   let describe_doc =  "Describe a $(mname) application."
@@ -152,17 +152,14 @@ module Make (Config : Functoria_sigs.CONFIG) = struct
       `I ("App vertices",
         "Represented as diamonds. The bold arrow is the functor part.");
     ] in
-    let f t =
-      let describe _ filename dotcmd dot eval =
-        R.ok @@ t#describe ~dotcmd ~dot ~eval filename
-      in
-      Term.(pure describe $ t#info $ output $ dotcmd $ dot $ full_eval)
+    let options =
+      Term.(pure (fun a b c d -> a, b, c, d)
+        $ output $ dotcmd $ dot $ full_eval)
     in
-    let f_no err =
-      let f () = Error err in
-      Term.(pure f $ base_keys)
+    let f map t = Term.pure @@ fun (output, dotcmd, dot, eval) ->
+      Config.describe ~dotcmd ~dot ~eval ~output map t
     in
-    with_config f f_no, term_info "describe" ~doc ~man
+    with_config f options, term_info "describe" ~doc ~man
 
   (* BUILD *)
   let build_doc = "Build a $(mname) application."
@@ -172,14 +169,10 @@ module Make (Config : Functoria_sigs.CONFIG) = struct
       `S "DESCRIPTION";
       `P build_doc
     ] in
-    let f t =
-      Term.(pure t#build $ t#info)
-    in
-    let f_no err =
-      let f = Error err in
-      Term.(pure f)
-    in
-    with_config f f_no, term_info "build" ~doc ~man
+    let options = Term.pure () in
+    let build info () = Config.build info in
+    let f map conf = Term.(pure build $ Config.eval map conf) in
+    with_config f options, term_info "build" ~doc ~man
 
   (* CLEAN *)
   let clean_doc =
@@ -190,14 +183,10 @@ module Make (Config : Functoria_sigs.CONFIG) = struct
       `S "DESCRIPTION";
       `P clean_doc;
     ] in
-    let f t =
-      Term.(pure t#clean $ t#info)
-    in
-    let f_no err =
-      let f _ = Error err in
-      Term.(pure f $ no_opam)
-    in
-    with_config f f_no, term_info "clean" ~doc ~man
+    let options = Term.pure () in
+    let clean info () = Config.clean info in
+    let f map conf = Term.(pure clean $ Config.eval map conf) in
+    with_config f options, term_info "clean" ~doc ~man
 
   (* HELP *)
   let help =
@@ -221,7 +210,7 @@ module Make (Config : Functoria_sigs.CONFIG) = struct
         | `Ok t when t = "topics" -> List.iter print_endline cmds; `Ok ()
         | `Ok t -> `Help (man_format, Some t) in
     let term =
-      Term.(pure help $ Term.man_format $ Term.choice_names $ topic $ base_keys)
+      Term.(pure help $ Term.man_format $ Term.choice_names $ topic $ Config.base_keys)
     in
     Term.ret term, Term.info "help" ~doc ~man
 


### PR DESCRIPTION
This is a bit more messy than I wanted, but it has several bonuses:
- Key.get and Key.eval are now completely safe. It is valid to use them inside
  configure and connect (since Info.t contains a keymap)
- Keys are fully immutable.
- The piece of hack for get_mode is a bit more isolated, and I can kill it when
  the time comes.

I also took the ocasion to clean up the interface with the tool.