### PR TITLE
Implement required keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-ci.sh
 env:
   global:
   - PACKAGE=functoria
-  - PINS="mirage:https://github.com/samoht/mirage.git#functoria mirage-skeleton.dev:https://github.com/Drup/mirage-skeleton.git#functoria"
+  - PINS="mirage:https://github.com/mirage/mirage.git mirage-skeleton.dev:https://github.com/Drup/mirage-skeleton.git#functoria"
   matrix:
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.01
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -562,7 +562,7 @@ module Make (P: S) = struct
       let keys = Config.extract_keys (P.create []) in
       let context = Key.context ~stage:`Configure keys in
       let f x = base_context := Some x; x in
-      Cmdliner.Term.(pure f $ context)
+      Cmdliner.Term.(pure f $ context ~with_required:false )
 
     type t = Config.t
     type evaluated = Graph.t * Info.t
@@ -577,7 +577,8 @@ module Make (P: S) = struct
       Log.set_section (Config.name t);
       Ok t
 
-    let if_context t = Key.context ~stage:`Configure @@ Config.keys t
+    let if_context t =
+      Key.context ~stage:`Configure ~with_required:false @@ Config.keys t
 
     let pp_info (f:('a, Format.formatter, unit) format -> 'a) level info =
       let verbose = Log.get_level () >= level in
@@ -591,9 +592,11 @@ module Make (P: S) = struct
     let build (_jobs, info) = log info; build info
     let describe (jobs, info) = show info; describe info jobs
 
-    let eval ~partial context t =
+    let eval ~partial ~with_required context t =
       let info = Config.eval ~partial context t in
-      let context = Key.context ~stage:`Configure (Key.deps info) in
+      let context =
+        Key.context ~with_required ~stage:`Configure (Key.deps info)
+      in
       let f map = Key.eval map info @@ map in
       Cmdliner.Term.(pure f $ context)
 

--- a/app/functoria_tool.ml
+++ b/app/functoria_tool.ml
@@ -147,7 +147,7 @@ module Make (Config: Functoria_sigs.CONFIG) = struct
   let set_color  = Lazy.from_fun load_color
   let set_verbose = Lazy.from_fun load_verbose
 
-  let with_config ?(with_eval=false) f options =
+  let with_config ?(with_eval=false) ?(with_required=false) f options =
     Lazy.force set_color;
     Lazy.force set_verbose;
     let show_error = function
@@ -160,7 +160,7 @@ module Make (Config: Functoria_sigs.CONFIG) = struct
         let term = match Term.eval_peek_opts if_context with
           | Some context, _ ->
             let partial = with_eval && not @@ load_fully_eval () in
-            Term.app f @@ Config.eval ~partial context t
+            Term.app f @@ Config.eval ~with_required ~partial context t
           | _, _ -> Term.pure (fun _ -> Error "Error during peeking.")
         in term
       | Error err -> Term.pure (fun _ -> Error err)
@@ -187,7 +187,8 @@ module Make (Config: Functoria_sigs.CONFIG) = struct
     let configure info (no_opam, no_opam_version, no_depext) =
       Config.configure info ~no_opam ~no_depext ~no_opam_version
     in
-    with_config (Term.pure configure) options, term_info "configure" ~doc ~man
+    with_config ~with_required:true (Term.pure configure) options,
+    term_info "configure" ~doc ~man
 
   (* DESCRIBE *)
   let describe_doc =  "Describe a $(mname) application."

--- a/lib/functoria_key.ml
+++ b/lib/functoria_key.ml
@@ -306,10 +306,20 @@ let pp fmt k = Fmt.string fmt (name k)
 let pp_deps fmt v = Set.pp pp fmt v.deps
 
 let pps p =
-  let f fmt (Any k) =
+  let pp' fmt k v =
     let default = if mem_u p k then Fmt.nop else Fmt.unit " (default)" in
     Fmt.pf fmt "%a=%a%a"
-      Fmt.(styled `Bold string) k.name (Arg.pp k.arg) (get p k) default ()
+      Fmt.(styled `Bold string) k.name
+      (Arg.pp k.arg) v
+      default ()
+  in
+  let f fmt (Any k) = match k.arg.Arg.kind, get p k with
+    | Arg.Required _, None ->
+      Fmt.(styled `Bold string) fmt k.name
+    | Arg.Opt _ ,v     -> pp' fmt k v
+    | Arg.Required _,v -> pp' fmt k v
+    | Arg.Flag ,v      -> pp' fmt k v
+    (* Warning 4 and GADT don't interact well. *)
   in
   fun ppf s -> Set.(pp f ppf @@ s)
 

--- a/lib/functoria_key.mli
+++ b/lib/functoria_key.mli
@@ -249,11 +249,15 @@ val aliases: t -> Set.t
 type context
 (** The type for values holding parsing context. *)
 
-val context: ?stage:Arg.stage -> Set.t -> context Cmdliner.Term.t
-(** [context ks] is a [Cmdliner]
+val context:
+  ?stage:Arg.stage -> with_required: bool ->
+  Set.t -> context Cmdliner.Term.t
+(** [context ~with_required ks] is a [Cmdliner]
     {{:http://erratique.ch/software/cmdliner/doc/Cmdliner.Term.html#TYPt}
     term} that evaluates into a parsing context for command-line
-    arguments. *)
+    arguments.
+    If [with_required] is false, it will only produce optional keys.
+*)
 
 val mem: context -> 'a value -> bool
 (** [mem c v] is [true] iff all the dependencies of [v] have been

--- a/lib/functoria_key.mli
+++ b/lib/functoria_key.mli
@@ -77,7 +77,7 @@ module Arg: sig
   (** The type for information about cross-stage command-line
       arguments. See
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner.Arg.html#arginfo}
-      Cmdliner.Arg#TYPEinfo}. *)
+      Cmdliner's arguments}. *)
 
   val info:
     ?docs:string -> ?docv:string -> ?doc:string -> ?env:string ->
@@ -114,7 +114,7 @@ module Arg: sig
   val flag: ?stage:stage -> info -> bool t
   (** [flag i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner.Arg.html#VALflag}
-      Cmdliner.Arg.opt} but for cross-stage command-line flags. If not
+      Cmdliner.Arg.flag} but for cross-stage command-line flags. If not
       set, [stage] is [`Both]. *)
 
 end

--- a/lib/functoria_key.mli
+++ b/lib/functoria_key.mli
@@ -111,6 +111,12 @@ module Arg: sig
       Cmdliner.Arg.opt} but for cross-stage optional command-line
       arguments. If not set, [stage] is [`Both]. *)
 
+  val required: ?stage:stage -> 'a converter -> info -> 'a option t
+  (** [required conv i] is similar to
+      {{:http://erratique.ch/software/cmdliner/doc/Cmdliner.Arg.html#VALrequired}
+      Cmdliner.Arg.required} but for cross-stage required command-line
+      arguments. If not set, [stage] is [`Both]. *)
+
   val flag: ?stage:stage -> info -> bool t
   (** [flag i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner.Arg.html#VALflag}

--- a/lib/functoria_sigs.mli
+++ b/lib/functoria_sigs.mli
@@ -56,6 +56,8 @@ module type CONFIG = sig
     dotcmd:string -> dot:bool -> output:string option ->
     (unit, string) Rresult.result
 
-  val eval: partial:bool -> Functoria_key.context -> t -> evaluated Cmdliner.Term.t
+  val eval:
+    partial:bool -> with_required:bool ->
+    Functoria_key.context -> t -> evaluated Cmdliner.Term.t
 
 end

--- a/runtime/functoria_runtime.ml
+++ b/runtime/functoria_runtime.ml
@@ -53,7 +53,7 @@ module Key = struct
   let create arg = { arg; value = None }
 
   let get t = match t.value with
-    | None   -> Arg.default t.arg
+    | None   -> invalid_arg "Key.get: Called too early. Please delay this call after cmdliner's evaluation."
     | Some v -> v
 
   let default t = Arg.default t.arg

--- a/runtime/functoria_runtime.ml
+++ b/runtime/functoria_runtime.ml
@@ -29,6 +29,9 @@ module Arg = struct
   let flag info = { info; kind = Flag }
   let opt conv default info = { info; kind = Opt (default, conv) }
   let required conv info = { info; kind = Required conv }
+  let key ?default c i = match default with
+    | None -> required c i
+    | Some d -> opt c d i
 
   let default (type a) (t : a t) = match t.kind with
     | Opt (d,_) -> Some d

--- a/runtime/functoria_runtime.ml
+++ b/runtime/functoria_runtime.ml
@@ -53,6 +53,8 @@ module Key = struct
     | None   -> Arg.default t.arg
     | Some v -> v
 
+  let default t = Arg.default t.arg
+
   let term (type a) (t: a t) =
     let set w = t.value <- Some w in
     let doc = Arg.info t.arg in

--- a/runtime/functoria_runtime.ml
+++ b/runtime/functoria_runtime.ml
@@ -19,6 +19,7 @@ module Arg = struct
   type 'a kind =
     | Opt : 'a * 'a Cmdliner.Arg.converter -> 'a kind
     | Flag: bool kind
+    | Required : 'a Cmdliner.Arg.converter -> 'a kind
 
   type 'a t = {
     info   : Cmdliner.Arg.info;
@@ -27,9 +28,13 @@ module Arg = struct
 
   let flag info = { info; kind = Flag }
   let opt conv default info = { info; kind = Opt (default, conv) }
+  let required conv info = { info; kind = Required conv }
+
   let default (type a) (t : a t) = match t.kind with
-    | Opt (d,_) -> d
-    | Flag -> false
+    | Opt (d,_) -> Some d
+    | Flag -> Some false
+    | Required _ -> None
+
   let kind t = t.kind
   let info t = t.info
 
@@ -56,6 +61,8 @@ module Key = struct
     | Arg.Flag     -> term @@ Cmdliner.Arg.(value & flag doc)
     | Arg.Opt (default, desc) ->
       term @@ Cmdliner.Arg.(value & opt desc default doc)
+    | Arg.Required desc ->
+      term @@ Cmdliner.Arg.(required & opt (some desc) None doc)
 
 end
 

--- a/runtime/functoria_runtime.mli
+++ b/runtime/functoria_runtime.mli
@@ -57,6 +57,11 @@ module Key: sig
   (** [get k] is the value of the key [k]. Use the default value if no
       command-line argument is provided. *)
 
+  val default : 'a t -> 'a option
+  (** [default k] is the default value of [k], if one is available.
+      This function can be called before cmdliner's evaluation.
+  *)
+
   val term: 'a t -> unit Cmdliner.Term.t
   (** [term k] is the [Cmdliner] term whose evaluation sets [k]s'
       value to the parsed command-line argument. *)

--- a/runtime/functoria_runtime.mli
+++ b/runtime/functoria_runtime.mli
@@ -32,6 +32,9 @@ module Arg: sig
   val opt: 'a Cmdliner.Arg.converter -> 'a -> Cmdliner.Arg.info -> 'a t
   (** [opt] is the runtime companion of {!Functoria_key.Arg.opt}. *)
 
+  val required: 'a Cmdliner.Arg.converter -> Cmdliner.Arg.info -> 'a t
+  (** [required] is the runtime companion of {!Functoria_key.Arg.required}. *)
+
   val flag: Cmdliner.Arg.info -> bool t
   (** [flag] is the runtime companion of {!Functoria_key.Arg.flag}. *)
 

--- a/runtime/functoria_runtime.mli
+++ b/runtime/functoria_runtime.mli
@@ -58,7 +58,9 @@ module Key: sig
 
   val get: 'a t -> 'a
   (** [get k] is the value of the key [k]. Use the default value if no
-      command-line argument is provided. *)
+      command-line argument is provided.
+      @raise Invalid_argument if called before cmdliner's evaluation.
+  *)
 
   val default : 'a t -> 'a option
   (** [default k] is the default value of [k], if one is available.

--- a/runtime/functoria_runtime.mli
+++ b/runtime/functoria_runtime.mli
@@ -35,6 +35,9 @@ module Arg: sig
   val required: 'a Cmdliner.Arg.converter -> Cmdliner.Arg.info -> 'a t
   (** [required] is the runtime companion of {!Functoria_key.Arg.required}. *)
 
+  val key: ?default:'a -> 'a Cmdliner.Arg.converter -> Cmdliner.Arg.info -> 'a t
+  (** [key] is either {!opt} or {!runtime}, depending if [~default] is provided. *)
+
   val flag: Cmdliner.Arg.info -> bool t
   (** [flag] is the runtime companion of {!Functoria_key.Arg.flag}. *)
 


### PR DESCRIPTION
Closes #15

I managed to avoid the `invalid_arg` by stating in the API that required keys were of type `'a option t`, which forces `get` to return an option.
This was slightly un-intuitive but it makes everything clicks into place much more smoothly.

@samoht: Ideas for a good documentation for `Arg.required` ?