### PR TITLE
Improve errors

### DIFF
--- a/app/functoria_tool.ml
+++ b/app/functoria_tool.ml
@@ -157,11 +157,14 @@ module Make (Config: Functoria_sigs.CONFIG) = struct
     match Lazy.force config with
     | Ok t ->
       let if_context = Config.if_context t in
+      let partial = with_eval && not @@ load_fully_eval () in
       let term = match Term.eval_peek_opts if_context with
         | Some context, _ ->
-          let partial = with_eval && not @@ load_fully_eval () in
           Term.app f @@ Config.eval ~with_required ~partial context t
-        | _, _ -> Term.pure (fun _ -> Error "Error during peeking.")
+        | _, _ ->
+          (* If peeking has failed, this should always fail too, but with
+             a good error message. *)
+          Term.app f @@ Config.eval ~with_required ~partial Functoria_key.empty_context t
       in
 
       let t =

--- a/app/functoria_tool.ml
+++ b/app/functoria_tool.ml
@@ -315,10 +315,11 @@ module Make (Config: Functoria_sigs.CONFIG) = struct
   ]
 
   let () =
-    match Term.eval_choice ~catch:false default (commands ()) with
-    | `Error _ -> exit 1
-    | _ -> ()
-    | exception (Functoria_misc.Log.Fatal s) ->
+    try match Term.eval_choice ~catch:false default (commands ()) with
+      | `Error _ -> exit 1
+      | _ -> ()
+    with
+    | Functoria_misc.Log.Fatal s ->
       Log.show_error "%s" s ;
       exit 1
 

--- a/lib/functoria_key.ml
+++ b/lib/functoria_key.ml
@@ -264,6 +264,7 @@ let filter_stage stage s = match stage with
 (* Key Map *)
 
 type context = Univ.t
+let empty_context = Univ.empty
 
 let get (type a) ctx (t : a key) : a =
   match t.arg.Arg.kind, Univ.find t.key ctx with

--- a/lib/functoria_key.mli
+++ b/lib/functoria_key.mli
@@ -249,6 +249,8 @@ val aliases: t -> Set.t
 type context
 (** The type for values holding parsing context. *)
 
+val empty_context : context
+
 val context:
   ?stage:Arg.stage -> with_required: bool ->
   Set.t -> context Cmdliner.Term.t

--- a/lib/functoria_misc.ml
+++ b/lib/functoria_misc.ml
@@ -125,7 +125,7 @@ module Log = struct
 
   let error_msg f = in_section ~color:red ~section:"[ERROR]" f
   let error fmt = Fmt.kstrf (fun x -> Error x) fmt
-  let fatal fmt = error_msg (Fmt.kstrf @@ fun s -> raise (Fatal s)) fmt
+  let fatal fmt = Fmt.kstrf (fun s -> raise (Fatal s)) fmt
   let show_error x = error_msg Fmt.pr x
   let info fmt = in_section ~color:green (log INFO) fmt
   let debug fmt = in_section ~color:green (log DEBUG) fmt

--- a/lib/functoria_misc.mli
+++ b/lib/functoria_misc.mli
@@ -110,6 +110,8 @@ module Log: sig
   val yellow: string Fmt.t
   val red: string Fmt.t
   val green: string Fmt.t
+
+  exception Fatal of string
 end
 
 (** Generation of fresh names *)


### PR DESCRIPTION
Should solve https://github.com/mirage/mirage/issues/459 and https://github.com/mirage/functoria/issues/37
The second fix is slightly hackish. I would prefer to do it another way, but until cmdliner improves
support from peek eval errors, I don't see another solution.