### PR TITLE
Fix for get_mode and provides a better solution.

### DIFF
--- a/app/functoria_graph.ml
+++ b/app/functoria_graph.ml
@@ -153,14 +153,15 @@ let add_pred_with_subst g preds v =
 let add_impl graph ~impl ~args ~deps =
   let v = G.V.create (Impl impl) in
   v,
-  graph
+  G.add_vertex graph v
   |> fold_lefti (fun i -> add_edge v (Parameter i)) args
   |> fold_lefti (fun i -> add_edge v (Dependency i)) deps
 
 let add_switch graph ~cond l =
   let v = G.V.create (If cond) in
   v,
-  List.fold_right (fun (p,v') -> add_edge v (Condition p) v') l graph
+  List.fold_right (fun (p,v') -> add_edge v (Condition p) v') l @@
+  G.add_vertex graph v
 
 let add_if graph ~cond ~else_ ~then_ =
   add_switch graph ~cond:(Key.map If.dir cond)
@@ -169,7 +170,7 @@ let add_if graph ~cond ~else_ ~then_ =
 let add_app graph ~f ~args =
   let v = G.V.create App in
   v,
-  graph
+  G.add_vertex graph v
   |> add_edge v Functor f
   |> fold_lefti (fun i -> add_edge v (Parameter i)) args
 

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -117,7 +117,7 @@ type job = JOB
 let job = Type JOB
 
 class ['ty] foreign
-    ?(keys=[]) ?(libraries=[]) ?(packages=[]) ?(deps=[]) module_name ty
+     ?(packages=[]) ?(libraries=[]) ?(keys=[]) ?(deps=[]) module_name ty
   : ['ty] configurable
   =
   let name = Name.create module_name ~prefix:"f" in
@@ -139,7 +139,7 @@ class ['ty] foreign
   end
 
 let foreign ?packages ?libraries ?keys ?deps module_name ty =
-  Impl (new foreign ?keys ?libraries ?packages ?deps module_name ty)
+  Impl (new foreign ?packages ?libraries ?keys ?deps module_name ty)
 
 (* {Misc} *)
 

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -125,10 +125,14 @@ val foreign:
     {- If [keys] is set, use the given {{!Functoria_key.key}keys} to
        parse at configure and runtime the command-line arguments
        before calling [name.connect].}
-    {- If [depes] is set, the given list of {{!abstract_impl}abstract}
+    {- If [deps] is set, the given list of {{!abstract_impl}abstract}
        implementations is added as data-dependencies: they will be
        initialized before calling [name.connect]. }
     }
+
+    For a more flexible definition of libraries and packages, or for a custom
+    configuration step, see the {!configurable} class type and the
+    {!class:foreign} class.
 *)
 
 (** Information about the final application. *)

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -222,6 +222,7 @@ class type ['ty] configurable = object
 
 end
 
+
 val impl: 'a configurable -> 'a impl
 (** [impl c] is the implementation of the configurable [c]. *)
 
@@ -246,6 +247,26 @@ class base_configurable: object
   method clean: Info.t -> (unit, string) Rresult.result
   method deps: abstract_impl list
 end
+
+class ['a] foreign:
+  ?packages:string list ->
+  ?libraries:string list ->
+  ?keys:key list ->
+  ?deps:abstract_impl list ->
+  string -> 'a typ -> ['a] configurable
+(** This class can be inherited to define a {!configurable} with an API
+    similar to {!foreign}.
+
+    In particular, it allows dynamic libraries and packages. Here is an example:
+    {[
+      let main = impl @@ object
+          inherit [_] foreign
+              ~packages:["vchan"]
+              "Unikernel.Main" (console @-> job)
+          method libraries = Key.(if_ is_xen) ["vchan.xen"] ["vchan.lwt"]
+        end
+    ]}
+*)
 
 (** {1 Sharing} *)
 

--- a/lib/functoria_misc.ml
+++ b/lib/functoria_misc.ml
@@ -128,6 +128,7 @@ module Log = struct
   let fatal fmt = Fmt.kstrf (fun s -> raise (Fatal s)) fmt
   let show_error x = error_msg Fmt.pr x
   let info fmt = in_section ~color:green (log INFO) fmt
+  let warn fmt = in_section ~color:green (log WARN) fmt
   let debug fmt = in_section ~color:green (log DEBUG) fmt
 
 end

--- a/lib/functoria_misc.mli
+++ b/lib/functoria_misc.mli
@@ -104,6 +104,7 @@ module Log: sig
     ('a, Format.formatter, unit, ('b, string) result) format4 -> 'a
   val fatal: ('a, Format.formatter, unit, 'b) format4 -> 'a
   val info: ('a, Format.formatter, unit) format -> 'a
+  val warn: ('a, Format.formatter, unit) format -> 'a
   val debug: ('a, Format.formatter, unit) format -> 'a
   val show_error: ('a, Format.formatter, unit) format -> 'a
   val blue: string Fmt.t


### PR DESCRIPTION
I was hesitant to expose foreign, but seing @talex5's [bug report](https://github.com/mirage/mirage/issues/470), I think it's better to expose it. It means there is a clear "upgrade" path when you have a foreign but want to add more things to it.

@samoht: Why wasn't Log.warn already there ? I used it for some debuging, so I left it there.