### PR TITLE
Functoria_tool refactoring

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -607,6 +607,5 @@ module Make (P: S) = struct
   end
 
   let get_base_context = Config.get_base_context
-  let run () = let module M = Functoria_tool.Make(Config) in ()
-
+  let run () = Functoria_tool.initialize (module Config)
 end

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -545,7 +545,11 @@ module Make (P: S) = struct
            directory.\n\
            Please specify one explictly on the command-line."
 
-  module Config = struct
+  module Config :
+  sig
+    include Functoria_sigs.CONFIG
+    val get_base_context : unit -> context
+  end = struct
     include P
 
     (* This is a hack to allow the implementation of

--- a/app/functoria_tool.ml
+++ b/app/functoria_tool.ml
@@ -321,24 +321,23 @@ module Make (Config: Functoria_sigs.CONFIG) = struct
       ~sdocs:global_option_section
       ~doc
       ~man
-
-  let commands () = [
-    configure ();
-    describe ();
-    build ();
-    clean ();
-    help;
-  ]
-
-  let () =
-    try match Term.eval_choice ~catch:false default (commands ()) with
-      | `Error _ -> exit 1
-      | _ -> ()
-    with
-    | Functoria_misc.Log.Fatal s ->
-      Log.show_error "%s" s ;
-      exit 1
 end
 
 let initialize (module Config:Functoria_sigs.CONFIG) =
- let module M = Make(Config) in ()
+  let module M = Make(Config) in
+  let open M in 
+  try
+    let commands = [
+      configure ();
+      describe ();
+      build ();
+      clean ();
+      help;
+    ] in
+    match Term.eval_choice ~catch:false default commands with
+      | `Error _ -> exit 1
+      | _ -> ()
+  with
+  | Functoria_misc.Log.Fatal s ->
+    Log.show_error "%s" s ;
+    exit 1

--- a/app/functoria_tool.ml
+++ b/app/functoria_tool.ml
@@ -325,5 +325,7 @@ module Make (Config: Functoria_sigs.CONFIG) = struct
     | Functoria_misc.Log.Fatal s ->
       Log.show_error "%s" s ;
       exit 1
-
 end
+
+let initialize (module Config:Functoria_sigs.CONFIG) =
+ let module M = Make(Config) in ()

--- a/app/functoria_tool.mli
+++ b/app/functoria_tool.mli
@@ -14,10 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Functoria_sigs
-
-(** Create a command line tool.
-    This modules initialize this application and has numerous
-    side effects. It should be loaded only once.
-*)
-module Make (M:CONFIG): sig end
+(** Create a command line tool.  This initializes this application and
+    has numerous side effects. It should be called only once. *)
+val initialize : (module Functoria_sigs.CONFIG) -> unit


### PR DESCRIPTION
Following @Drup's [suggestion](https://github.com/mirage/mirage/issues/472#issuecomment-161034146) to
> untangle the pile of spagetti that is functoria_tool

here's a start at a refactoring.

The changes are probably uncontroversial:

* Adding a signature (0779422)
* Switching from a functor with side effects and an ignored return value to a function (2ebc289)
* Lifting code that doesn't depend on a functor argument (b63f47c), i.e. changing
  ```ocaml
  module F(X:S) =
  struct
    let f x = e
    ...
  end
  ```

  to

  ```ocaml
  let f x = e
  module F(X:S) =
  struct
    ...
  end
  ```
* Moving side effects out of a functor body (89e1bea), i.e. changing
  ```ocaml
  module F(X:S) =
  struct
    ...
    let () =
      f ()
  end
  let g () = let module M = F(X) in ()
  ```

  to

  ```ocaml
  module F(X:S) =
  struct
    ...
  end
  let g () = let module M = F(X) in M.(f ())
  ```
