### PR TITLE
Solve multi-connect issues

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -232,7 +232,7 @@ module Engine = struct
     tbl
 
   let meta_init fmt (connect_name, result_name) =
-    Fmt.pf fmt "let _%s =@[@ %s () @]in@ " result_name connect_name
+    Fmt.pf fmt "let _%s =@[@ Lazy.force %s @]in@ " result_name connect_name
 
   let meta_connect error fmt (connect_name, result_name) =
     Fmt.pf fmt
@@ -248,10 +248,10 @@ module Engine = struct
        by prefixing with "_". This also avoid warnings. *)
     let names = List.map (fun x -> (x, "_"^x)) names in
     Fmt.pf fmt
-      "@[<v 2>let %s () =@ \
+      "@[<v 2>let %s = lazy (@ \
        %a\
        %a\
-       %s@]@."
+       %s@ )@]@."
       iname
       Fmt.(list ~sep:nop meta_init) names
       Fmt.(list ~sep:nop @@ meta_connect error) names
@@ -263,9 +263,9 @@ module Engine = struct
       "@[<v 2>\
        let () =@ \
          let t =@ \
-         %s () >>= function@ \
+         Lazy.force %s >>= function@ \
          | `Error _e -> exit 1@ \
-         | `Ok _ -> %s ()@ \
+         | `Ok _ -> Lazy.force %s@ \
        in run t@]"
       key main
 


### PR DESCRIPTION
This is a proposal to solve https://github.com/mirage/mirage/issues/476 and all the other related issues.
Currently, functoria emits a unit-function to delay execution. This assumes referential transparency, which is completely wrong in the context of connect functions. Using lazy should solve the issue.
@yomimono tested under xen and it seems to work.

It breaks https://github.com/mirage/mirage/pull/466
I will try come up with a good idea on how to fix that, otherwise, there is an ugly fix [here](https://github.com/Drup/mirage/commit/5e92bef72a1a7672e95b15f4e9d1b800892ab7e1).

I think this is a good solution, but there might be an Lwt-only solution that doesn't involve lazyness. Ideas ?