### PR TITLE
Support options such as --help and --version without a config file

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -548,12 +548,11 @@ module Make (P: S) = struct
     (* This is a hack to allow the implementation of
        [Mirage.get_mode]. Once it is removed, the notion of base context
        should be removed as well. *)
+    exception No_base_key_map
     let base_context_ref = ref None
     let get_base_context () = match !base_context_ref with
       | Some x -> x
-      | None ->
-        invalid_arg "Base key map is not available at this point. Please stop \
-                     messing with functoria's invariants."
+      | None -> raise No_base_key_map
 
     let pp_info (f:('a, Format.formatter, unit) format -> 'a) level info =
       let verbose = Log.get_level () >= level in
@@ -573,10 +572,13 @@ module Make (P: S) = struct
     let root = Cmd.realpath (Filename.dirname file) in
     let file = root / Filename.basename file in
     set_config_file file;
-    compile_and_dynlink file >>= fun () ->
-    registered () >>= fun t ->
-    Log.set_section (Config.name t);
-    Ok t
+    try
+      compile_and_dynlink file >>= fun () ->
+      registered () >>= fun t ->
+      Log.set_section (Config.name t);
+      Ok t
+    with Config'.No_base_key_map ->
+      Error "Access to base key map is unavailable at this point"      
 
   let get_base_context = Config'.get_base_context
 
@@ -612,8 +614,28 @@ module Make (P: S) = struct
     | `Version
     | `Help -> ()
 
+  let handle_parse_args_no_config error argv =
+    try
+    let module Cmd = Functoria_command_line in
+    let open Cmdliner in
+    let result = Functoria_command_line.parse_args ~name:P.name ~version:P.version
+        ~configure:(Term.pure ())
+        ~describe:(Term.pure ())
+        ~build:(Term.pure ())
+        ~clean:(Term.pure ())
+        ~help:base_context_arg
+        argv
+    in
+    match result with
+    | `Error _ -> exit 1
+    | `Ok Cmd.Help -> ()
+    | `Ok (Cmd.Configure _ | Cmd.Describe _ | Cmd.Build _ | Cmd.Clean _) ->
+      Functoria_misc.Log.fatal "%s" error
+    | `Version
+    | `Help -> ()
+    with Invalid_argument _ -> assert false
 
-  let run_with_argv argv = 
+  let run_with_argv ?base_context argv =
     let module Cmd = Functoria_command_line in
     (* 1. Pre-parse the arguments to load the config file, set the log
      *    level and colour, and determine whether the graph should be fully
@@ -632,35 +654,45 @@ module Make (P: S) = struct
     let config_file = Cmd.read_config_file argv in
 
     (* 2. Load the config from the config file. *)
-    let config = fatalize_error (load' config_file) in
-    let config_keys = Config.keys config in
-    let context_args = Key.context ~stage:`Configure ~with_required:false config_keys in
-    let context = 
-      match Cmdliner.Term.eval_peek_opts ~argv context_args with
-      | _, `Ok context -> context
-      | _ -> Functoria_key.empty_context
-    in
+    (* First, set the base context ref, which might be accessed in the
+       config file. *)
+    let () = Config'.base_context_ref := base_context in
+    (* There are three possible outcomes:
+         1. the config file is found and loaded succeessfully
+         2. no config file is specified
+         3. an attempt is made to access the base keys at this point.
+            when they weren't loaded *)
 
-    (* 3. Parse the command-line and handle the result. *)
-    handle_parse_args_result
-      (Functoria_command_line.parse_args ~name:P.name ~version:P.version
-         ~configure:(Config'.eval ~with_required:true ~partial:false context config)
-         ~describe:(Config'.eval ~with_required:false ~partial:(not full_eval) context config)
-         ~build:(Config'.eval ~with_required:false ~partial:false context config)
-         ~clean:(Config'.eval ~with_required:false ~partial:false context config)
-         ~help:base_context_arg
-         argv)
+    match load' config_file with
+    | Error err -> handle_parse_args_no_config err argv
+    | Ok config ->
+       let config_keys = Config.keys config in
+       let context_args = Key.context ~stage:`Configure ~with_required:false config_keys in
+       let context = 
+         match Cmdliner.Term.eval_peek_opts ~argv context_args with
+         | _, `Ok context -> context
+         | _ -> Functoria_key.empty_context
+       in
 
+       (* 3. Parse the command-line and handle the result. *)
+       handle_parse_args_result
+         (Functoria_command_line.parse_args ~name:P.name ~version:P.version
+            ~configure:(Config'.eval ~with_required:true ~partial:false context config)
+            ~describe:(Config'.eval ~with_required:false ~partial:(not full_eval) context config)
+            ~build:(Config'.eval ~with_required:false ~partial:false context config)
+            ~clean:(Config'.eval ~with_required:false ~partial:false context config)
+            ~help:base_context_arg
+            argv)
 
   let run () =
     (* Store the "base_context"  *)
-    let () =
+    let base_context =
       match Cmdliner.Term.eval_peek_opts ~argv:Sys.argv base_context_arg with
-        _, `Ok x -> Config'.base_context_ref := Some x
-      | _ -> ()
+        _, `Ok x -> Some x
+      | _ -> None
     in
     try
-      run_with_argv Sys.argv
+      run_with_argv ?base_context Sys.argv
     with Functoria_misc.Log.Fatal s ->
       begin
         Functoria_misc.Log.show_error "%s" s;

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -578,7 +578,8 @@ module Make (P: S) = struct
       Log.set_section (Config.name t);
       Ok t
     with Config'.No_base_key_map ->
-      Error "Access to base key map is unavailable at this point"      
+      Error ("Access to base key map is not available before configuration. \
+              For dynamically configured devices, please use the configurable class.")
 
   let get_base_context = Config'.get_base_context
 

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -615,7 +615,6 @@ module Make (P: S) = struct
     | `Help -> ()
 
   let handle_parse_args_no_config error argv =
-    try
     let module Cmd = Functoria_command_line in
     let open Cmdliner in
     let result = Functoria_command_line.parse_args ~name:P.name ~version:P.version
@@ -633,7 +632,6 @@ module Make (P: S) = struct
       Functoria_misc.Log.fatal "%s" error
     | `Version
     | `Help -> ()
-    with Invalid_argument _ -> assert false
 
   let run_with_argv ?base_context argv =
     let module Cmd = Functoria_command_line in


### PR DESCRIPTION
Fixes mirage/mirage#472.

### Before

```
$ mirage help
[ERROR] No configuration file config.ml found.
Please specify the configuration file using -f.
```
```
$ mirage --version
[ERROR] No configuration file config.ml found.
Please specify the configuration file using -f.
```
```
$ mirage help config
[ERROR] No configuration file config.ml found.
Please specify the configuration file using -f.
```

### After

```
$ mirage help
MIRAGE(1)                        Mirage Manual                       MIRAGE(1)



NAME
       mirage - The mirage application builder
[...]
```
```
$ mirage --version
2.6.1
```
```
$ mirage help config
MIRAGE-CONFIGURE(1)              Mirage Manual             MIRAGE-CONFIGURE(1)



NAME
       mirage-configure - Configure a mirage application.
[...]
```

