### PR TITLE
[RFC] Better error reporting and logging

### DIFF
--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -107,7 +107,7 @@ class base_configurable = object
   method packages: string list Key.value = Key.pure []
   method keys: Key.t list = []
   method connect (_:Info.t) (_:string) l =
-    Printf.sprintf "return (`Ok (%s))" (String.concat ", " l)
+    Printf.sprintf "return (%s)" (String.concat ", " l)
   method configure (_: Info.t): (unit,string) R.t = R.ok ()
   method clean (_: Info.t): (unit,string) R.t = R.ok ()
   method deps: abstract_impl list = []
@@ -130,7 +130,7 @@ class ['ty] foreign
     method packages = Key.pure packages
     method connect _ modname args =
       Fmt.strf
-        "@[%s.start@ %a@ >>= fun t -> Lwt.return (`Ok t)@]"
+        "@[%s.start@ %a@]"
         modname
         Fmt.(list ~sep:sp string)  args
     method clean _ = R.ok ()


### PR DESCRIPTION
This branch makes some changes to allow better diagnostics from functoria unikernels:

- It removes functoria's default error handling (which is to ignore the actual error value and fail with the name of an internal variable). Devices are now expected to handle errors themselves and report something sensible.

- `connect` is replaced by `connect_raw`, which doesn't automatically force its arguments. This allows devices to control the order of initialisation. In particular, this allows a log reporter device to configure logging *before* starting the initialisation of the main unikernel.

See [mirage/better-errors](https://github.com/mirage/mirage/compare/master...talex5:better-errors?expand=1) for the corresponding changes to mirage.

See <https://github.com/talex5/canopy-data/blob/master/Posts/Errors.md> for examples of the new errors and logging this makes possible.