### PR TITLE
Add connect_raw to avoid forcing inputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ env:
   - PACKAGE=functoria
   - PINS="mirage-skeleton.dev:https://github.com/mirage/mirage-skeleton.git"
   matrix:
-  - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.01
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -42,7 +42,7 @@ let sys_argv = impl @@ object
     method ty = argv
     method name = "argv"
     method module_name = "Sys"
-    method !connect _info _m _ =
+    method! private connect _info _m _ =
       "return (`Ok Sys.argv)"
   end
 
@@ -78,12 +78,12 @@ let keys (argv: argv impl) = impl @@ object
     method ty = job
     method name = Keys.name
     method module_name = Key.module_name
-    method !configure = Keys.configure
-    method !clean = Keys.clean
-    method !libraries = Key.pure [ "functoria.runtime" ]
-    method !packages = Key.pure [ "functoria" ]
-    method !deps = [ abstract argv ]
-    method !connect info modname = function
+    method! configure = Keys.configure
+    method! clean = Keys.clean
+    method! libraries = Key.pure [ "functoria.runtime" ]
+    method! packages = Key.pure [ "functoria" ]
+    method! deps = [ abstract argv ]
+    method! private connect info modname = function
       | [ argv ] ->
         Fmt.strf
           "return (Functoria_runtime.with_argv %s.runtime_keys %S %s)"
@@ -121,17 +121,17 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
     method name = "info"
     val gen_file = String.lowercase gen_modname  ^ ".ml"
     method module_name = gen_modname
-    method !libraries = Key.pure ["functoria.runtime"]
-    method !packages = Key.pure ["functoria"]
-    method !connect _ modname _ = Fmt.strf "return (`Ok %s.info)" modname
+    method! libraries = Key.pure ["functoria.runtime"]
+    method! packages = Key.pure ["functoria"]
+    method! private connect _ modname _ = Fmt.strf "return (`Ok %s.info)" modname
 
-    method !clean i =
+    method! clean i =
       let file = Info.root i / gen_file in
       Cmd.remove file;
       Cmd.remove (file ^".in");
       R.ok ()
 
-    method !configure i =
+    method! configure i =
       let file = Info.root i / gen_file in
       Log.info "%a %s" Log.blue "Generating: " gen_file;
       let f fmt =
@@ -231,31 +231,12 @@ module Engine = struct
     Graph.fold f g @@ R.ok () >>| fun () ->
     tbl
 
-  let meta_init fmt (connect_name, result_name) =
-    Fmt.pf fmt "let _%s =@[@ Lazy.force %s @]in@ " result_name connect_name
-
-  let meta_connect error fmt (connect_name, result_name) =
-    Fmt.pf fmt
-      "_%s >>= function@ \
-       | `Error _e -> %s@ \
-       | `Ok %s ->@ "
-      result_name
-      (error connect_name)
-      result_name
-
-  let emit_connect fmt (error, iname, names, connect_string) =
-    (* We avoid potential collision between double application
-       by prefixing with "_". This also avoid warnings. *)
-    let names = List.map (fun x -> (x, "_"^x)) names in
+  let emit_connect fmt (ident, connect) =
     Fmt.pf fmt
       "@[<v 2>let %s = lazy (@ \
-       %a\
-       %a\
-       %s@ )@]@."
-      iname
-      Fmt.(list ~sep:nop meta_init) names
-      Fmt.(list ~sep:nop @@ meta_connect error) names
-      (connect_string @@ List.map snd names)
+       %t@ \
+       )@]@."
+      ident connect
 
   let emit_run key main =
     (* "exit 1" is ok in this code, since cmdliner will print help. *)
@@ -280,7 +261,8 @@ module Engine = struct
         Graph.Tbl.add tbl v ident;
         let names = List.map (Graph.Tbl.find tbl) (args @ deps) in
         Codegen.append_main "%a"
-          emit_connect (error, ident, names, c#connect info modname)
+          emit_connect (ident, c#connect_raw ~error ~names ~info ~modname)
+
     in
     Graph.fold (fun v () -> f v) g ();
     let main_name = Graph.Tbl.find tbl @@ Graph.find_root g in

--- a/app/functoria_graph.ml
+++ b/app/functoria_graph.ml
@@ -49,7 +49,7 @@ type subconf = <
   keys: Key.t list;
   packages: string list Key.value;
   libraries: string list Key.value;
-  connect: Info.t -> string -> string list -> string;
+  connect_raw: error:(string -> string) -> names:string list -> info:Info.t -> modname:string -> Format.formatter -> unit;
   configure: Info.t -> (unit, string) Rresult.result;
   clean: Info.t -> (unit, string) Rresult.result;
 >

--- a/app/functoria_graph.mli
+++ b/app/functoria_graph.mli
@@ -24,7 +24,7 @@ type subconf = <
   keys       : key list;
   packages   : string list value;
   libraries  : string list value;
-  connect    : Info.t -> string -> string list -> string;
+  connect_raw: error:(string -> string) -> names:string list -> info:Info.t -> modname:string -> Format.formatter -> unit;
   configure  : Info.t -> (unit, string) Rresult.result;
   clean      : Info.t -> (unit, string) Rresult.result;
 >

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -174,6 +174,18 @@ module Info: sig
 
 end
 
+type connecting_input
+
+val meta_init : Format.formatter -> string -> connecting_input
+(** [meta_init input f] writes to [f] code to start connecting [input]. *)
+
+val meta_connect : (string -> string) -> Format.formatter -> connecting_input -> string
+(** [meta_connect error f input] writes to [f] code to wait for [input] to finish
+    connecting and returns the name of the variable holding the result.
+    [error input] is used to generate error handling code for the case where [input]
+    fails. TODO: we should handle errors from a device in that device itself, not in
+    its users. Doing that would allow us to remove [errors] from this API. *)
+
 (** Signature for configurable module implementations. A
     [configurable] is a module implementation which contains a runtime
     state which can be set either at configuration time (by the
@@ -200,11 +212,12 @@ class type ['ty] configurable = object
   (** [libraries] is the list of OCamlfind libraries to include and
       link with the configurable. *)
 
-  method connect: Info.t -> string -> string list -> string
-  (** [connect info mod args] is the code to execute in order to
-      initialize the state associated with the module [mod] (usually
-      calling [mod.connect]) with the arguments [args], in the context
-      of the project information [info]. *)
+  method connect_raw: error:(string -> string) -> names:string list -> info:Info.t -> modname:string -> Format.formatter -> unit
+  (** [connect_raw ~error ~names ~info ~modname fmt] writes to [fmt] code
+      to construct an instance of the module. Normally, this means forcing
+      each input in [names], waiting for them all to finish, and calling
+      [connect]. The helper functions [meta_init] and [meta_connect] may
+      be useful for this. *)
 
   method configure: Info.t -> (unit, string) Rresult.result
   (** [configure info] is the code to execute in order to configure
@@ -227,7 +240,7 @@ class type ['ty] configurable = object
 end
 
 
-val impl: 'a configurable -> 'a impl
+val impl: 'a #configurable -> 'a impl
 (** [impl c] is the implementation of the configurable [c]. *)
 
 (** [base_configurable] pre-defining many methods from the
@@ -246,7 +259,19 @@ class base_configurable: object
   method libraries: string list value
   method packages: string list value
   method keys: key list
-  method connect: Info.t -> string -> string list -> string
+
+  method connect_raw: error:(string -> string) -> names:string list -> info:Info.t -> modname:string -> Format.formatter -> unit
+  (** [connect_raw ~error ~names ~info ~modname fmt] writes to [fmt] code
+      to construct an instance of the module. The default implementation uses
+      [meta_init] to force each input in [names], then [meta_connect] to
+      wait for them all to finish, and then calls [self#connect]. *)
+
+  method private connect: Info.t -> string -> string list -> string
+  (** [connect info mod args] is the code to execute in order to
+      initialize the state associated with the module [mod] (usually
+      calling [mod.connect]) with the arguments [args], in the context
+      of the project information [info]. It is called by [connect_raw]. *)
+
   method configure: Info.t -> (unit, string) Rresult.result
   method clean: Info.t -> (unit, string) Rresult.result
   method deps: abstract_impl list


### PR DESCRIPTION
This is just the logging changes from https://github.com/mirage/functoria/pull/55, as requested in last week's IRC discussion.

For logging devices, we want to initialise as early as possible. With this change, a logging device can use `connect_raw` instead of `connect` to get the unforced inputs (typically, any devices it needs to
operate plus the unikernel to be monitored). It can then force these in the right order.

Notes:

- `impl` now accepts subclasses so that this patch does not require any changes to mirage. The `connect` methods in mirage should ideally be marked as `private` at some point.

- This API exposes the ugly `error` argument in `connect_raw`. This will go away once the rest of the original PR is merged.

- For testing, the https://github.com/talex5/mirage/tree/logging branch uses this to provide a `with_mirage_logs` function. We agreed that this API should change (so that unikernels get logging by default). However, I don't believe this will require any further changes to functoria.