### PR TITLE
don't unset "yes" for opam depext

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -448,7 +448,7 @@ module Make (P: S) = struct
                 if Cmd.exists "opam-depext"
                 then Ok (Log.info "opam depext is installed.")
                 else Cmd.opam ?color "install" ["depext"]
-              end >>= fun () -> Cmd.opam ~yes:false "depext" ps
+              end >>= fun () -> Cmd.opam "depext" ps
             end >>= fun () ->
             Cmd.opam ?color "install" ps
           ) else version_error ()


### PR DESCRIPTION
opam-depext >= 1.0.1 respects OPAMYES, so don't unset it when we're invoking depext.  This is an attempt to fix https://travis-ci.org/mirage/mirage/jobs/146580003 .