### PR TITLE
Removing the build subcommand

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -473,17 +473,6 @@ module Make (P: S) = struct
         configure_main i jobs
       )
 
-  let make () =
-    match Cmd.uname_s () with
-    | Some ("FreeBSD" | "OpenBSD" | "NetBSD" | "DragonFly") -> "gmake"
-    | _ -> "make"
-
-  let build i =
-    Log.info "%a %s" Log.blue "Build:" (get_config_file ());
-    Cmd.in_dir (Info.root i) (fun () ->
-        Cmd.run "%s build" (make ())
-      )
-
   let clean i (_init, job) =
     Log.info "%a %s" Log.blue "Clean:"  (get_config_file ());
     let root = Info.root i in
@@ -595,9 +584,6 @@ module Make (P: S) = struct
     | `Ok (Cmd.Describe { result = (jobs, info); dotcmd; dot; output }) ->
       Config'.pp_info Fmt.(pf stdout) Log.INFO info;
       fatalize_error (describe info jobs ~dotcmd ~dot ~output)
-    | `Ok (Cmd.Build (_, info)) ->
-      Config'.pp_info Log.info Log.DEBUG info;
-      fatalize_error (build info)
     | `Ok (Cmd.Clean (jobs, info)) ->
       Config'.pp_info Log.info Log.DEBUG info;
       fatalize_error (clean info jobs)
@@ -610,7 +596,6 @@ module Make (P: S) = struct
     let result = Functoria_command_line.parse_args ~name:P.name ~version:P.version
         ~configure:(Term.pure ())
         ~describe:(Term.pure ())
-        ~build:(Term.pure ())
         ~clean:(Term.pure ())
         ~help:base_context_arg
         argv
@@ -618,7 +603,7 @@ module Make (P: S) = struct
     match result with
     | `Ok Cmd.Help -> ()
     | `Error _
-    | `Ok (Cmd.Configure _ | Cmd.Describe _ | Cmd.Build _ | Cmd.Clean _) ->
+    | `Ok (Cmd.Configure _ | Cmd.Describe _ | Cmd.Clean _) ->
       Functoria_misc.Log.fatal "%s" error
     | `Version
     | `Help -> ()
@@ -664,7 +649,6 @@ module Make (P: S) = struct
          (Functoria_command_line.parse_args ~name:P.name ~version:P.version
             ~configure:(Config'.eval ~with_required:true ~partial:false context config)
             ~describe:(Config'.eval ~with_required:false ~partial:(not full_eval) context config)
-            ~build:(Config'.eval ~with_required:false ~partial:false context config)
             ~clean:(Config'.eval ~with_required:false ~partial:false context config)
             ~help:base_context_arg
             argv)

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -137,7 +137,6 @@ type 'a describe_args = {
 type 'a action =
     Configure of 'a config_args
   | Describe of 'a describe_args
-  | Build of 'a
   | Clean of 'a
   | Help
 
@@ -198,20 +197,6 @@ struct
                  $ output
                  $ dotcmd
                  $ dot)
-
-  (** The 'build' subcommand *)
-  let build result =
-    let doc = "Build a $(mname) application." in
-    term_info "build" ~doc
-      ~man:[
-        `S "DESCRIPTION";
-        `P doc;
-      ]
-      ~arg:Term.(pure (fun _ _ _ info -> Build info)
-                 $ verbose
-                 $ color
-                 $ config_file
-                 $ result)
 
   (** The 'clean' subcommand *)
   let clean info_ =
@@ -296,11 +281,10 @@ let read_full_eval : string array -> bool =
     | _, `Ok b -> b
     | _ -> false
 
-let parse_args ~name ~version ~configure ~describe ~build ~clean ~help argv =
+let parse_args ~name ~version ~configure ~describe ~clean ~help argv =
   Cmdliner.Term.eval_choice ~argv ~catch:false (Subcommands.default ~name ~version) [
     Subcommands.configure configure;
     Subcommands.describe describe;
-    Subcommands.build build;
     Subcommands.clean clean;
     Subcommands.help help;
   ]

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -70,7 +70,6 @@ type 'a describe_args = {
 type 'a action =
     Configure of 'a config_args
   | Describe of 'a describe_args
-  | Build of 'a
   | Clean of 'a
   | Help
 (** A value of type [action] is the result of parsing command-line arguments using
@@ -81,7 +80,6 @@ open Cmdliner.Term
 val parse_args : name:string -> version:string ->
   configure:'a t ->
   describe:'a t ->
-  build:'a t -> 
   clean:'a t ->
   help:_ t ->
   string array ->
@@ -106,10 +104,6 @@ val parse_args : name:string -> version:string ->
                     [--dot-command=COMMAND]
                     [--dot]
                     [extra arguments]
-      name build [-v|--verbose]
-                 [--color=(auto|always|never)]
-                 [-f FILE | --file=FILE]
-                 [extra arguments]
       name clean [-v|--verbose]
                  [--color=(auto|always|never)]
                  [-f FILE | --file=FILE]
@@ -117,7 +111,7 @@ val parse_args : name:string -> version:string ->
       name help [-v|--verbose]
                 [--color=(auto|always|never)]
                 [--man-format=(groff|pager|plain)]
-                [configure|describe|build|clean|help|topics]
+                [configure|describe|clean|help|topics]
                 [extra arguments]
       name [-v|--verbose]
            [--color=(auto|always|never)]

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -30,7 +30,6 @@ let test_configure _ =
     Cmd.parse_args ~name:"name" ~version:"0.2"
       ~configure:extra_term
       ~describe:extra_term
-      ~build:extra_term
       ~clean:extra_term
       ~help:extra_term
       [|"name"; "configure"; "--xyz"; "--verbose"; "--no-opam"|]
@@ -54,7 +53,6 @@ let test_describe _ =
     Cmd.parse_args ~name:"name" ~version:"0.2"
       ~configure:extra_term
       ~describe:extra_term
-      ~build:extra_term
       ~clean:extra_term
       ~help:extra_term
       [|"name"; "describe"; "--cde"; "--file=tests/config.ml";
@@ -65,27 +63,6 @@ let test_describe _ =
                          dotcmd = "dot";
                          dot = false;
                          output = None }))
-    result
-
-
-let test_build _ =
-  let extra_term = Cmdliner.(Term.(
-      pure (fun xyz cde -> (xyz, cde))
-      $ Arg.(value (flag (info ["x"; "xyz"])))
-      $ Arg.(value (flag (info ["c"; "cde"])))
-    ))
-  in
-  let result =
-    Cmd.parse_args ~name:"name" ~version:"0.2"
-      ~configure:extra_term
-      ~describe:extra_term
-      ~build:extra_term
-      ~clean:extra_term
-      ~help:extra_term
-      [|"name"; "build"; "--cde"; "-x"; "--color=never"; "-v"; "-v"|]
-  in
-  assert_equal
-    (`Ok (Cmd.Build (true, true)))
     result
 
 
@@ -100,7 +77,6 @@ let test_clean _ =
     Cmd.parse_args ~name:"name" ~version:"0.2"
       ~configure:extra_term
       ~describe:extra_term
-      ~build:extra_term
       ~clean:extra_term
       ~help:extra_term
       [|"name"; "clean"|]
@@ -121,7 +97,6 @@ let test_help _ =
     Cmd.parse_args ~name:"name" ~version:"0.2"
       ~configure:extra_term
       ~describe:extra_term
-      ~build:extra_term
       ~clean:extra_term
       ~help:extra_term
       [|"name"; "help"; "--help"; "plain"; "--verbose"|]
@@ -139,7 +114,6 @@ let test_default _ =
     Cmd.parse_args ~name:"name" ~version:"0.2"
       ~configure:extra_term
       ~describe:extra_term
-      ~build:extra_term
       ~clean:extra_term
       ~help:extra_term
       [|"name"|]
@@ -235,9 +209,6 @@ let suite = "Command-line parsing tests" >:::
 
     "describe"
     >:: test_describe;
-
-    "build"
-    >:: test_build;
 
     "clean"
     >:: test_clean;


### PR DESCRIPTION
this was legacy from before functoria, MirageOS instructions contain
`mirage configure` followed by `make` -- there's no need for this indirection