### PR TITLE
functoria-runtime: new opam package

### DIFF
--- a/_tags
+++ b/_tags
@@ -6,12 +6,11 @@ true: keep_locs
 
 <app>    : include
 <lib>    : include
-<runtime>: include
 
 <{lib,app}/*>: package(unix dynlink cmdliner rresult fmt.tty ocamlgraph astring)
 
 # Force the runtime to be unix-independent.
-<runtime/*>: dontlink(unix)
-<runtime/*>: package(cmdliner), package(fmt)
+<runtime/*>: dontlink(unix str num threads)
+<runtime/*>: package(cmdliner fmt)
 
 <tests/*>: package(oUnit cmdliner fmt.cli rresult astring)

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -82,8 +82,8 @@ let keys (argv: argv impl) = impl @@ object
     method module_name = Key.module_name
     method !configure = Keys.configure
     method !clean = Keys.clean
-    method !libraries = Key.pure [ "functoria.runtime" ]
-    method !packages = Key.pure [ "functoria" ]
+    method !libraries = Key.pure [ "functoria-runtime" ]
+    method !packages = Key.pure [ "functoria-runtime" ]
     method !deps = [ abstract argv ]
     method !connect info modname = function
       | [ argv ] ->
@@ -123,8 +123,8 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
     method name = "info"
     val gen_file = String.Ascii.lowercase gen_modname  ^ ".ml"
     method module_name = gen_modname
-    method !libraries = Key.pure ["functoria.runtime"]
-    method !packages = Key.pure ["functoria"]
+    method !libraries = Key.pure ["functoria-runtime"]
+    method !packages = Key.pure ["functoria-runtime"]
     method !connect _ modname _ = Fmt.strf "return %s.info" modname
 
     method !clean i =

--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "Gabriel Radanne <drupyog@zoho.com>"
+authors:      [ "Thomas Gazagnaire"
+                "Anil Madhavapeddy"
+                "Dave Scott"
+                "Thomas Leonard"
+                "Gabriel Radanne" ]
+homepage:     "https://github.com/mirage/functoria"
+bug-reports:  "https://github.com/mirage/functoria/issues"
+dev-repo:     "https://github.com/mirage/functoria.git"
+doc:          "https://mirage.github.io/functoria/"
+license:      "ISC"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg"     {build & >= "0.7.3"}
+  "cmdliner" {>= "0.9.8"}
+  "fmt"
+]
+available: [ocaml-version >= "4.02"]

--- a/functoria.opam
+++ b/functoria.opam
@@ -1,5 +1,4 @@
 opam-version: "1.2"
-name:         "functoria"
 maintainer:   "Gabriel Radanne <drupyog@zoho.com>"
 authors:      [ "Thomas Gazagnaire"
                 "Anil Madhavapeddy"
@@ -12,9 +11,9 @@ dev-repo:     "https://github.com/mirage/functoria.git"
 doc:          "https://mirage.github.io/functoria/"
 license:      "ISC"
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" "--tests" "true"]
   ["ocaml" "pkg/pkg.ml" "test"]
 ]
 depends: [

--- a/pkg/META.functoria
+++ b/pkg/META.functoria
@@ -1,21 +1,10 @@
 description = "Functoria configuration tool"
 version = "%%VERSION_NUM%%"
-requires = "unix dynlink cmdliner rresult fmt.tty functoria.runtime ocamlgraph astring"
+requires = "unix dynlink cmdliner rresult fmt.tty ocamlgraph astring"
 archive(byte) = "functoria.cma"
 archive(native) = "functoria.cmxa"
 plugin(byte) = "functoria.cma"
 plugin(native) = "functoria.cmxs"
-
-package "runtime" (
- description = "Functoria runtime"
- version = "%%VERSION_NUM%%"
- requires = "cmdliner fmt"
- archive(byte) = "functoria-runtime.cma"
- archive(native) = "functoria-runtime.cmxa"
- plugin(byte) = "functoria-runtime.cma"
- plugin(native) = "functoria-runtime.cmxs"
- exists_if = "functoria-runtime.cma"
-)
 
 package "app" (
  description = "Functoria tool helpers"

--- a/pkg/META.functoria-runtime
+++ b/pkg/META.functoria-runtime
@@ -1,0 +1,8 @@
+description = "Functoria runtime"
+version = "%%VERSION_NUM%%"
+requires = "cmdliner fmt"
+archive(byte) = "functoria-runtime.cma"
+archive(native) = "functoria-runtime.cmxa"
+plugin(byte) = "functoria-runtime.cma"
+plugin(native) = "functoria-runtime.cmxs"
+exists_if = "functoria-runtime.cma"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -3,15 +3,34 @@
 #require "topkg"
 open Topkg
 
+let metas = [
+  Pkg.meta_file ~install:false "pkg/META.functoria";
+  Pkg.meta_file ~install:false "pkg/META.functoria-runtime";
+]
+
 let opams =
-  let lint_deps_excluding = Some ["ounit"; "oUnit"] in
-  [Pkg.opam_file ~lint_deps_excluding "opam"]
+  let install = false in
+  [
+    Pkg.opam_file ~install ~lint_deps_excluding:(Some ["ounit";"oUnit"]) "functoria.opam" ;
+    Pkg.opam_file ~install ~lint_deps_excluding:None "functoria-runtime.opam"
+  ]
 
 let () =
-  Pkg.describe ~opams "functoria" @@ fun c ->
-  Ok [
-    Pkg.mllib "lib/functoria.mllib";
-    Pkg.mllib "app/functoria-app.mllib";
-    Pkg.mllib "runtime/functoria-runtime.mllib";
-    Pkg.test  "tests/test_functoria_command_line";
-  ]
+  Pkg.describe ~metas ~opams "functoria" @@ fun c ->
+  match Conf.pkg_name c with
+  | "functoria" ->
+    Ok [
+      Pkg.lib "pkg/META.functoria" ~dst:"META";
+      Pkg.lib "functoria.opam" ~dst:"opam" ;
+      Pkg.mllib "lib/functoria.mllib";
+      Pkg.mllib "app/functoria-app.mllib";
+      Pkg.test  "tests/test_functoria_command_line"
+    ]
+  | "functoria-runtime" ->
+    Ok [
+      Pkg.lib "pkg/META.functoria-runtime" ~dst:"META" ;
+      Pkg.lib "functoria-runtime.opam" ~dst:"opam" ;
+      Pkg.mllib "runtime/functoria-runtime.mllib"
+    ]
+  | other ->
+    R.error_msgf "unknown package name: %s" other


### PR DESCRIPTION
exclude <runtime> from include in _tags
no need to require (in META) functoria.runtime from functoria.runtime