### PR TITLE
[RFC] No opam , version constraints for packages of unikernels

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -2,6 +2,7 @@ B _build/*
 S src/*
 S runtime/*
 PKG unix dynlink cmdliner rresult fmt ocamlgraph astring
+PKG oUnit
 
 FLG -w +A-4-6-7-9-40-42-44-48
 FLG -w -32-34-37

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -82,8 +82,7 @@ let keys (argv: argv impl) = impl @@ object
     method module_name = Key.module_name
     method !configure = Keys.configure
     method !clean = Keys.clean
-    method !libraries = Key.pure [ "functoria-runtime" ]
-    method !packages = Key.pure [ "functoria-runtime" ]
+    method !packages = Key.pure [package "functoria-runtime"]
     method !deps = [ abstract argv ]
     method !connect info modname = function
       | [ argv ] ->
@@ -98,6 +97,8 @@ let keys (argv: argv impl) = impl @@ object
 type info = Info
 let info = Type Info
 
+(* hannes is pretty sure the following pp needs adjustments, but unclear to me
+   what exactly to do here? i.e. who reads the formatted stuff in again? *)
 let pp_libraries fmt l =
   Fmt.pf fmt "[@ %a]"
     Fmt.(iter ~sep:(unit ";@ ") List.iter @@ fmt "%S") l
@@ -113,7 +114,7 @@ let pp_dump_info module_name fmt i =
     "%s.{@ name = %S;@ \
      @[<v 2>packages = %a@]@ ;@ @[<v 2>libraries = %a@]@ }"
     module_name (Info.name i)
-    pp_packages (Info.packages i)
+    pp_packages (Info.package_names i)
     pp_libraries (Info.libraries i)
 
 let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
@@ -123,8 +124,7 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
     method name = "info"
     val gen_file = String.Ascii.lowercase gen_modname  ^ ".ml"
     method module_name = gen_modname
-    method !libraries = Key.pure ["functoria-runtime"]
-    method !packages = Key.pure ["functoria-runtime"]
+    method !packages = Key.pure [package "functoria-runtime"]
     method !connect _ modname _ = Fmt.strf "return %s.info" modname
 
     method !clean i =
@@ -159,21 +159,15 @@ module Engine = struct
     | App     -> Key.Set.empty
 
   module M = struct
-    type t = String.Set.t Key.value
-    let union x y = Key.(pure String.Set.union $ x $ y)
-    let empty = Key.pure String.Set.empty
+    type t = package list Key.value
+    let union x y = Key.(pure List.append $ x $ y)
+    let empty = Key.pure []
   end
 
   let packages =
     let open Graph in
     Graph.collect (module M) @@ function
-    | Impl c     -> Key.map String.Set.of_list c#packages
-    | If _ | App -> M.empty
-
-  let libraries =
-    let open Graph in
-    Graph.collect (module M) @@ function
-    | Impl c     -> Key.map String.Set.of_list c#libraries
+    | Impl c     -> c#packages
     | If _ | App -> M.empty
 
   (* Return a unique variable name holding the state of the given
@@ -316,8 +310,7 @@ module Config = struct
   type t = {
     name     : string;
     root     : string;
-    libraries: String.Set.t Key.value;
-    packages: String.Set.t Key.value;
+    packages: package list Key.value;
     keys    : Key.Set.t;
     init    : job impl list;
     jobs    : Graph.t;
@@ -335,29 +328,25 @@ module Config = struct
     in
     Key.Set.fold f all_keys skeys
 
-  let make ?(keys=[]) ?(libraries=[]) ?(packages=[]) ?(init=[]) name root
+  let make ?(keys=[]) ?(packages=[]) ?(init=[]) name root
       main_dev =
     let jobs = Graph.create main_dev in
-    let libraries = Key.pure @@ String.Set.of_list libraries in
-    let packages = Key.pure @@ String.Set.of_list packages in
+    let packages = Key.pure @@ packages in
     let keys = Key.Set.(union (of_list keys) (get_if_context jobs)) in
-    { libraries; packages; keys; name; root; init; jobs }
+    { packages; keys; name; root; init; jobs }
 
   let eval ~partial context
-      { name = n; root; packages; libraries; keys; jobs; init }
+      { name = n; root; packages; keys; jobs; init }
     =
     let e = Graph.eval ~partial ~context jobs in
-    let pkgs = Key.(pure String.Set.union $ packages $ Engine.packages e) in
-    let libs = Key.(pure String.Set.union $ libraries $ Engine.libraries e) in
+    let packages = Key.(pure List.append $ packages $ Engine.packages e) in
     let keys = Key.Set.elements (Key.Set.union keys @@ Engine.keys e) in
-    Key.(pure (fun libraries packages _ context ->
+    Key.(pure (fun packages _ context ->
         ((init, e),
          Info.create
-           ~libraries:(String.Set.elements libraries)
-           ~packages:(String.Set.elements packages)
+           ~packages
            ~keys ~context ~name:n ~root))
-         $ libs
-         $ pkgs
+         $ packages
          $ of_deps (Set.of_list keys))
 
   (* Extract all the keys directly. Useful to pre-resolve the keys
@@ -402,11 +391,11 @@ module Make (P: S) = struct
 
   let get_root () = Filename.dirname @@ get_config_file ()
 
-  let register ?(packages=[]) ?(libraries=[]) ?keys ?(init=[]) name jobs =
+  let register ?(packages=[]) ?keys ?(init=[]) name jobs =
     let keys = match keys with None -> [] | Some x -> x in
     let root = get_root () in
     let main_dev = P.create (init @ jobs) in
-    let c = Config.make ~keys ~libraries ~packages ~init name root main_dev in
+    let c = Config.make ~keys ~packages ~init name root main_dev in
     configuration := Some c
 
   let registered () =
@@ -433,6 +422,7 @@ module Make (P: S) = struct
 
   let configure i jobs =
     Log.info "%a %s" Log.blue "Using configuration:"  (get_config_file ());
+    Log.info "opam: %a" (Info.opam ?name:None) i ;
     Cmd.in_dir (Info.root i) (fun () -> configure_main i jobs)
 
   let clean i (_init, job) =

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -530,7 +530,7 @@ module Make (P: S) = struct
     function
     | `Error _ -> exit 1
     | `Ok Cmd.Help -> ()
-    | `Ok (Cmd.Configure {result = (jobs, info)}) ->
+    | `Ok (Cmd.Configure (jobs, info)) ->
       Config'.pp_info Log.info Log.DEBUG info;
       fatalize_error (configure info jobs)
     | `Ok (Cmd.Describe { result = (jobs, info); dotcmd; dot; output }) ->

--- a/app/functoria_app.mli
+++ b/app/functoria_app.mli
@@ -89,8 +89,7 @@ module Make (P: S): sig
   open Functoria
 
   val register:
-    ?packages:string list ->
-    ?libraries:string list ->
+    ?packages:package list ->
     ?keys:key list ->
     ?init:job impl list ->
     string -> job impl list -> unit

--- a/app/functoria_app.mli
+++ b/app/functoria_app.mli
@@ -154,13 +154,6 @@ module Cmd: sig
 
   val ocaml_version: unit -> int * int
   (** [ocaml_version] is [ocaml -version]'s output. *)
-
-  module OCamlfind: sig
-    val query:
-      ?predicates:string list -> ?format:string -> ?recursive:bool ->
-      string list -> (string list, string) Rresult.result
-  end
-
 end
 
 (** Console logging. FIXME: replace by [Bos.Log]. *)

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -36,21 +36,6 @@ let term_info title ~doc ~man ~arg =
  * Argument specifications
  *)
 
-(** Argument specification for --no-opam *)
-let no_opam =
-  mk_flag ["no-opam"]
-    "Do not manage the OPAM configuration. \
-     This will result in dependent libraries not being automatically \
-     installed during the configuration phase."
-
-(** Argument specification for --no-opam-version-check *)
-let no_opam_version_check =
-  mk_flag ["no-opam-version-check"] "Bypass the OPAM version check."
-
-(** Argument specification for --no-depext *)
-let no_depext =
-  mk_flag ["no-depext"] "Skip installation of external dependencies."
-
 (** Argument specification for --eval *)
 let full_eval =
   mk_flag ["eval"]
@@ -122,9 +107,6 @@ let verbose : Functoria_misc.Log.level Term.t =
 
 type 'a config_args = {
   result: 'a;
-  no_opam: bool;
-  no_depext: bool;
-  no_opam_version: bool
 }
 
 type 'a describe_args = {
@@ -153,15 +135,12 @@ struct
         `S "DESCRIPTION";
         `P "The $(b,configure) command initializes a fresh $(mname) application."
       ]
-      ~arg:Term.(pure (fun _ _ _ info no_opam no_opam_version no_depext -> 
-          Configure { result = info; no_opam; no_depext; no_opam_version })
+      ~arg:Term.(pure (fun _ _ _ info -> 
+          Configure { result = info })
                  $ verbose
                  $ color
                  $ config_file
-                 $ result
-                 $ no_opam
-                 $ no_opam_version_check
-                 $ no_depext)
+                 $ result)
 
   (** The 'describe' subcommand *)
   let describe result =

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -105,10 +105,6 @@ let verbose : Functoria_misc.Log.level Term.t =
   in
   Term.(pure log_level_of_verbosity $ Arg.(value & flag_all doc))
 
-type 'a config_args = {
-  result: 'a;
-}
-
 type 'a describe_args = {
   result: 'a;
   dotcmd: string;
@@ -117,7 +113,7 @@ type 'a describe_args = {
 }
 
 type 'a action =
-    Configure of 'a config_args
+    Configure of 'a
   | Describe of 'a describe_args
   | Clean of 'a
   | Help
@@ -135,8 +131,7 @@ struct
         `S "DESCRIPTION";
         `P "The $(b,configure) command initializes a fresh $(mname) application."
       ]
-      ~arg:Term.(pure (fun _ _ _ info -> 
-          Configure { result = info })
+      ~arg:Term.(pure (fun _ _ _ info -> Configure info)
                  $ verbose
                  $ color
                  $ config_file

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -42,10 +42,7 @@ val read_full_eval : string array -> bool
     value indicates whether the option is present in [argv]. *)
 
 type 'a config_args = {
-  result: 'a;
-  no_opam: bool;
-  no_depext: bool;
-  no_opam_version: bool
+  result: 'a
 }
 (** A value of type [config_args] is the result of parsing the arguments to a
     [configure] subcommand.
@@ -92,9 +89,6 @@ val parse_args : name:string -> version:string ->
       name configure [-v|--verbose]
                      [--color=(auto|always|never)]
                      [-f FILE | --file=FILE]
-                     [--no-opam]
-                     [--no-opam-version-check]
-                     [--no-depext]
                      [extra arguments]
       name describe [--eval]
                     [-v|--verbose]

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -41,16 +41,6 @@ val read_full_eval : string array -> bool
 (** [read_full_eval argv] reads the --eval option from [argv]; the return
     value indicates whether the option is present in [argv]. *)
 
-type 'a config_args = {
-  result: 'a
-}
-(** A value of type [config_args] is the result of parsing the arguments to a
-    [configure] subcommand.
-
-    The [result] field holds the result of parsing the "additional" arguments
-    whose specification is passed as the [configure] argument to
-    {!parse_args}. *)
-
 type 'a describe_args = {
   result: 'a;
   dotcmd: string;
@@ -65,7 +55,7 @@ type 'a describe_args = {
     {!parse_args}. *)
 
 type 'a action =
-    Configure of 'a config_args
+    Configure of 'a
   | Describe of 'a describe_args
   | Clean of 'a
   | Help

--- a/app/functoria_graph.ml
+++ b/app/functoria_graph.ml
@@ -47,8 +47,7 @@ type subconf = <
   name: string;
   module_name: string;
   keys: Key.t list;
-  packages: string list Key.value;
-  libraries: string list Key.value;
+  packages: package list Key.value;
   connect: Info.t -> string -> string list -> string;
   configure: Info.t -> (unit, string) Rresult.result;
   clean: Info.t -> (unit, string) Rresult.result;

--- a/app/functoria_graph.mli
+++ b/app/functoria_graph.mli
@@ -22,8 +22,7 @@ type subconf = <
   name       : string;
   module_name: string;
   keys       : key list;
-  packages   : string list value;
-  libraries  : string list value;
+  packages   : package list value ;
   connect    : Info.t -> string -> string list -> string;
   configure  : Info.t -> (unit, string) Rresult.result;
   clean      : Info.t -> (unit, string) Rresult.result;

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -21,39 +21,149 @@ open Functoria_misc
 
 module Key = Functoria_key
 
-module Info = struct
+type package = {
+  opam : string ;
+  build : bool ;
+  ocamlfind : String.Set.t ;
+  min : string option ;
+  max : string option
+}
 
+module Package = struct
+  (* we could have copied code from opam, but that's LGPL *)
+  let version_of_string s =
+    let r = List.fold_left (fun acc v ->
+        match Astring.String.to_int v with
+        | Some n -> n :: acc
+        | None -> invalid_arg "cannot parse version number")
+        []
+        (Astring.String.cuts ~sep:"." s)
+    in
+    List.rev r
+
+  let compare_version v1 v2 =
+    let rec cmp a b =
+      match a, b with
+      | x::xs, y::ys when x = y -> cmp xs ys
+      | x::_, y::_ -> compare x y
+      | [], y::ys when y = 0 -> cmp [] ys
+      | [], y::_ -> compare 0 y
+      | x::xs, [] when x = 0 -> cmp xs []
+      | x::_, [] -> compare x 0
+      | [], [] -> 0
+    in
+    let v1 = version_of_string v1
+    and v2 = version_of_string v2
+    in
+    cmp v1 v2
+
+  let m_option f a b = match a, b with
+    | None, None -> None
+    | Some a, None -> Some a
+    | None, Some b -> Some b
+    | Some a, Some b -> Some (f a b)
+
+  let merge opam a b =
+    let ocamlfind = String.Set.union a.ocamlfind b.ocamlfind
+    and min =
+      m_option
+        (fun a b -> match compare_version a b with 0 -> a | 1 -> a | _ -> b)
+        a.min b.min
+    and max =
+      m_option
+        (fun a b -> match compare_version a b with 0 -> a | 1 -> b | _ -> a)
+        a.max b.max
+    and build = if not a.build || not b.build then false else true
+    in
+    match min, max with
+    | Some a, Some b when compare_version a b >= 0 ->
+      invalid_arg ("version constraint for " ^ opam ^ " must be that min is smaller than max")
+    | _ -> Some { opam ; build ; ocamlfind ; min ; max }
+
+  let package ?(build = false) ?sublibs ?ocamlfind ?min ?max opam =
+    let ocamlfind = match sublibs, ocamlfind with
+      | None, None -> [opam]
+      | Some xs, None -> opam :: List.map (fun x -> opam ^ "." ^ x) xs
+      | None, Some a -> a
+      | Some _, Some _ -> invalid_arg "only either ~sub or ~ocamlfind may be specified"
+    in
+    let ocamlfind = String.Set.of_list ocamlfind in
+    match min, max with
+    | Some min, Some max when compare_version min max >= 0 -> invalid_arg "min must be < max"
+    | _ -> { opam ; build ; ocamlfind ; min ; max }
+end
+
+let package = Package.package
+
+module Info = struct
   type t = {
     name: string;
     root: string;
     keys: Key.Set.t;
     context: Key.context;
-    libraries: String.Set.t;
-    packages: String.Set.t;
+    packages: package String.Map.t;
   }
 
   let name t = t.name
   let root t = t.root
-  let libraries t = String.Set.elements t.libraries
-  let packages t = String.Set.elements t.packages
+  let libraries t =
+    String.Set.elements
+      (List.fold_left String.Set.union String.Set.empty
+         (List.map (fun x -> x.ocamlfind)
+            (List.filter (fun x -> x.build = false)
+               (List.map snd (String.Map.bindings t.packages)))))
+  let package_names t =
+    List.map fst
+      (List.filter (fun (_, p) -> p.build = false)
+         (String.Map.bindings t.packages))
+  let packages t = List.map snd (String.Map.bindings t.packages)
   let keys t = Key.Set.elements t.keys
   let context t = t.context
 
-  let create ?(packages=[]) ?(libraries=[]) ?(keys=[]) ~context ~name ~root =
-    let libraries = String.Set.of_list libraries in
-    let packages = String.Set.of_list packages in
+  let create ~packages ~keys ~context ~name ~root =
     let keys = Key.Set.of_list keys in
-    { name; root; keys; libraries; packages; context }
+    let packages = List.fold_left (fun m p ->
+        let n = p.opam in
+        match String.Map.find p.opam m with
+        | None -> String.Map.add n p m
+        | Some p' -> match Package.merge p.opam p p' with
+          | Some p -> String.Map.add n p m
+          | None -> invalid_arg "bad constraints")
+        String.Map.empty packages
+    in
+    { name; root; keys; packages; context }
 
-  let pp verbose ppf { name ; root ; keys ; context ; libraries ; packages } =
+  let exts_to_string min max build =
+    let bui = if build then "build & " else "" in
+    match min, max with
+    | None, None -> if build then "{build}" else ""
+    | Some a, None -> Printf.sprintf "{%s>=\"%s\"}" bui a
+    | None, Some b -> Printf.sprintf "{%s<\"%s\"}" bui b
+    | Some a, Some b -> Printf.sprintf "{%s>=\"%s\" & <\"%s\"}" bui a b
+
+  let pp_package t ppf p =
+    Fmt.pf ppf "%s%s%s@ %s" t p.opam t (exts_to_string p.min p.max p.build)
+
+  let pp_packages ?(surround = "") ?sep ppf t =
+    Fmt.pf ppf "%a" (Fmt.iter ?sep List.iter (pp_package surround)) (packages t)
+
+  let pp verbose ppf ({ name ; root ; keys ; context ; _ } as t) =
     let show name = Fmt.pf ppf "@[<2>%a@ %a@]@," Log.blue name in
-    let set = Fmt.iter ~sep:(Fmt.unit ",@ ") String.Set.iter Fmt.string in
+    let list = Fmt.iter ~sep:(Fmt.unit ",@ ") List.iter Fmt.string in
     show "Name      " Fmt.string name;
     show "Root      " Fmt.string root;
     show "Keys      " (Key.pps context) keys;
-    if verbose then show "Libraries " set libraries;
-    if verbose then show "Packages  " set packages
+    if verbose then show "Libraries " list (libraries t);
+    if verbose then
+      show "Packages  "
+        (pp_packages ?surround:None ~sep:(Fmt.unit ",@ ")) t
 
+  let opam ?name ppf t =
+    let name = match name with None -> t.name | Some x -> x in
+    Fmt.pf ppf "opam-version: \"1.2\"@." ;
+    Fmt.pf ppf "name: \"%s\"@." name ;
+    Fmt.pf ppf "depends: [ @[<2>%a@]@ ]@."
+      (pp_packages ~surround:"\"" ~sep:(Fmt.unit "@ ")) t
 end
 
 type _ typ =
@@ -83,8 +193,7 @@ module rec Typ: sig
     method name: string
     method module_name: string
     method keys: Key.t list
-    method packages: string list Key.value
-    method libraries: string list Key.value
+    method packages: package list Key.value
     method connect: Info.t -> string -> string list -> string
     method configure: Info.t -> (unit, string) R.t
     method clean: Info.t -> (unit, string) R.t
@@ -105,8 +214,7 @@ let rec match_impl kv ~default = function
   | (f, i) :: t -> If (Key.(pure ((=) f) $ kv), i, match_impl kv ~default t)
 
 class base_configurable = object
-  method libraries: string list Key.value = Key.pure []
-  method packages: string list Key.value = Key.pure []
+  method packages: package list Key.value = Key.pure []
   method keys: Key.t list = []
   method connect (_:Info.t) (_:string) l =
     Printf.sprintf "return (%s)" (String.concat ~sep:", " l)
@@ -119,7 +227,7 @@ type job = JOB
 let job = Type JOB
 
 class ['ty] foreign
-     ?(packages=[]) ?(libraries=[]) ?(keys=[]) ?(deps=[]) module_name ty
+     ?(packages=[]) ?(keys=[]) ?(deps=[]) module_name ty
   : ['ty] configurable
   =
   let name = Name.create module_name ~prefix:"f" in
@@ -128,7 +236,6 @@ class ['ty] foreign
     method name = name
     method module_name = module_name
     method keys = keys
-    method libraries = Key.pure libraries
     method packages = Key.pure packages
     method connect _ modname args =
       Fmt.strf
@@ -140,8 +247,8 @@ class ['ty] foreign
     method deps = deps
   end
 
-let foreign ?packages ?libraries ?keys ?deps module_name ty =
-  Impl (new foreign ?packages ?libraries ?keys ?deps module_name ty)
+let foreign ?packages ?keys ?deps module_name ty =
+  Impl (new foreign ?packages ?keys ?deps module_name ty)
 
 (* {Misc} *)
 

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -127,7 +127,8 @@ val package :
     name is by default the same as [opam], you can specify [~sublibs] to add
     additional sublibraries (e.g. [~sublibs:["mirage"] "foo"] will result in the
     findlib names [ ["foo"; "foo.mirage"] ].  In case the findlib name is
-    disjoint (or empty), use [~ocamlfind].  Version constraints are given as
+    disjoint (or empty), use [~ocamlfind].  Specifying both [~ocamlfind] and
+    [~sublibs] leads to an invalid argument.  Version constraints are given as
     [min] (inclusive) and [max] (exclusive). *)
 
 (** {1:app Application Builder}
@@ -148,7 +149,7 @@ val foreign:
     [typ].
 
     {ul
-    {- If [packages] is set, then the given OPAM packages are
+    {- If [packages] is set, then the given packages are
        installed before compiling the current application.}
     {- If [keys] is set, use the given {{!Functoria_key.key}keys} to
        parse at configure and runtime the command-line arguments

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -99,6 +99,37 @@ module type KEY = module type of struct include Functoria_key end
 (** The signature for run-time and configure-time command-line
     keys. *)
 
+(** {1:pkg Package dependencies}
+
+    For specifying opam package dependencies, the type {!package} is used.  It
+    consists of the opam package name, the ocamlfind names, and optional lower
+    and upper bounds.  The version constraints are merged with other modules.
+*)
+
+type package = private {
+  opam : string ;
+  build : bool ;
+  ocamlfind : Astring.String.Set.t ;
+  min : string option ;
+  max : string option
+}
+(** The type of a package *)
+
+val package :
+  ?build:bool ->
+  ?sublibs:string list ->
+  ?ocamlfind:string list ->
+  ?min:string ->
+  ?max:string ->
+  string -> package
+(** [package ~build ~sublibs ~ocamlfind ~min ~max opam] is a [package].  [Build]
+    indicates a build-time dependency only, defaults to [false]. The ocamlfind
+    name is by default the same as [opam], you can specify [~sublibs] to add
+    additional sublibraries (e.g. [~sublibs:["mirage"] "foo"] will result in the
+    findlib names [ ["foo"; "foo.mirage"] ].  In case the findlib name is
+    disjoint (or empty), use [~ocamlfind].  Version constraints are given as
+    [min] (inclusive) and [max] (exclusive). *)
+
 (** {1:app Application Builder}
 
     Values of type {!impl} are tied to concrete module implementation
@@ -109,8 +140,7 @@ module type KEY = module type of struct include Functoria_key end
     application. See {!Functoria_app} for details. *)
 
 val foreign:
-  ?packages:string list ->
-  ?libraries:string list ->
+  ?packages:package list ->
   ?keys:key list ->
   ?deps:abstract_impl list ->
   string -> 'a typ -> 'a impl
@@ -120,8 +150,6 @@ val foreign:
     {ul
     {- If [packages] is set, then the given OPAM packages are
        installed before compiling the current application.}
-    {- If [libraries] is set, the given OCamlfind libraries are
-       included and linked with the module [name].}
     {- If [keys] is set, use the given {{!Functoria_key.key}keys} to
        parse at configure and runtime the command-line arguments
        before calling [name.connect].}
@@ -130,9 +158,8 @@ val foreign:
        initialized before calling [name.connect]. }
     }
 
-    For a more flexible definition of libraries and packages, or for a custom
-    configuration step, see the {!configurable} class type and the
-    {!class:foreign} class.
+    For a more flexible definition of packages, or for a custom configuration
+    step, see the {!configurable} class type and the {!class:foreign} class.
 *)
 
 (** Information about the final application. *)
@@ -148,9 +175,12 @@ module Info: sig
   (** Directory in which the configuration is done. *)
 
   val libraries: t -> string list
-  (** OCamlfind libraries needed by the project. *)
+  (** OCamlfind libraries needed by the project at runtime. *)
 
-  val packages: t -> string list
+  val package_names: t -> string list
+  (** OPAM packages names needed by the project at runtime. *)
+
+  val packages: t -> package list
   (** OPAM packages needed by the project. *)
 
   val keys: t -> key list
@@ -163,15 +193,17 @@ module Info: sig
   (** [create context n r] contains information about the application
       being built. *)
   val create:
-    ?packages:string list ->
-    ?libraries:string list ->
-    ?keys:key list ->
+    packages:package list ->
+    keys:key list ->
     context:context ->
     name:string ->
     root:string -> t
 
   val pp: bool -> t Fmt.t
 
+  val opam : ?name:string -> t Fmt.t
+  (** [opam ~name t] generates an opam file including all dependencies.  The
+      [name] will be used as package name, defaults to {!name}. *)
 end
 
 (** Signature for configurable module implementations. A
@@ -192,13 +224,9 @@ class type ['ty] configurable = object
   (** [module_name] is the name of the module implementing the
       configurable. *)
 
-  method packages: string list value
+  method packages: package list value
   (** [packages] is the list of OPAM packages which needs to be
       installed before compiling the configurable. *)
-
-  method libraries: string list value
-  (** [libraries] is the list of OCamlfind libraries to include and
-      link with the configurable. *)
 
   method connect: Info.t -> string -> string list -> string
   (** [connect info mod args] is the code to execute in order to
@@ -243,8 +271,7 @@ val impl: 'a configurable -> 'a impl
     ]}
 *)
 class base_configurable: object
-  method libraries: string list value
-  method packages: string list value
+  method packages: package list value
   method keys: key list
   method connect: Info.t -> string -> string list -> string
   method configure: Info.t -> (unit, string) Rresult.result
@@ -253,21 +280,21 @@ class base_configurable: object
 end
 
 class ['a] foreign:
-  ?packages:string list ->
-  ?libraries:string list ->
+  ?packages:package list ->
   ?keys:key list ->
   ?deps:abstract_impl list ->
   string -> 'a typ -> ['a] configurable
 (** This class can be inherited to define a {!configurable} with an API
     similar to {!foreign}.
 
-    In particular, it allows dynamic libraries and packages. Here is an example:
+    In particular, it allows dynamic packages. Here is an example:
     {[
       let main = impl @@ object
           inherit [_] foreign
-              ~packages:["vchan"]
               "Unikernel.Main" (console @-> job)
-          method libraries = Key.(if_ is_xen) ["vchan.xen"] ["vchan.lwt"]
+          method packages = Key.(if_ is_xen)
+              [package ~sublibs:["xen"] "vchan"]
+              [package ~sublibs:["lwt"] "vchan"]
         end
     ]}
 *)

--- a/lib/functoria_misc.ml
+++ b/lib/functoria_misc.ml
@@ -158,24 +158,6 @@ module Cmd = struct
         | Error err -> Log.error "%s" err
       ) fmt
 
-  let opam cmd ?(yes=true) ?switch ?color deps =
-    let color = match color with
-      | None -> ""
-      | Some `None -> " --color=never"
-      | Some `Ansi_tty -> " --color=always"
-    in
-    let deps = String.concat ~sep:" " deps in
-    (* Note: we don't redirect output to the log as installation can
-     * take a long time and the user will want to see what is
-       happening. *)
-    let yes = if yes then " --yes " else "" in
-    let redirect = false in
-    let switch = match switch with
-      | None   -> ""
-      | Some s -> Printf.sprintf " --switch=%s" s
-    in
-    run ~redirect "opam %s%s%s%s %s" cmd yes color switch deps
-
   let in_dir dir f =
     let pwd = Sys.getcwd () in
     let reset () =

--- a/lib/functoria_misc.ml
+++ b/lib/functoria_misc.ml
@@ -234,25 +234,6 @@ module Cmd = struct
         with _ -> 0, 0
       end
     | _ -> 0, 0
-
-  module OCamlfind = struct
-
-    let query ?predicates ?(format="%p") ?(recursive=false) xs =
-      let pred = match predicates with
-        | None    -> ""
-        | Some ps -> "-predicates '" ^ String.concat ~sep:"," ps ^ "'"
-      and fmt  = "-format '" ^ format ^ "'"
-      and r    = if recursive then "-recursive" else ""
-      and pkgs = String.concat ~sep:" " xs
-      in
-      read "ocamlfind query %s %s %s %s" fmt pred r pkgs
-      >>| fun out -> Astring.String.cuts ~sep:"\n" out
-
-    let installed lib =
-      Sys.command ("ocamlfind query " ^ lib ^ " 2>&1 1>/dev/null") = 0
-
-  end
-
 end
 (* {Misc informations} *)
 

--- a/lib/functoria_misc.mli
+++ b/lib/functoria_misc.mli
@@ -50,14 +50,6 @@ module Cmd: sig
   val uname_m: unit -> string option
   val uname_r: unit -> string option
   val ocaml_version: unit -> int * int
-
-  module OCamlfind: sig
-    val query:
-      ?predicates:string list -> ?format:string -> ?recursive:bool ->
-      string list -> (string list, string) result
-    val installed: string -> bool
-  end
-
 end
 
 

--- a/lib/functoria_misc.mli
+++ b/lib/functoria_misc.mli
@@ -45,9 +45,6 @@ module Cmd: sig
   val with_file: string -> (Format.formatter -> 'a) -> 'a
   val with_process_in: string -> (in_channel -> 'a) -> 'a
   val with_process_out: string -> (out_channel -> 'a) -> 'a
-  val opam:
-    string -> ?yes:bool -> ?switch:string -> ?color:Fmt.style_renderer ->
-    string list -> (unit, string) result
   val in_dir: string -> (unit -> 'a) -> 'a
   val uname_s: unit -> string option
   val uname_m: unit -> string option

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -32,13 +32,10 @@ let test_configure _ =
       ~describe:extra_term
       ~clean:extra_term
       ~help:extra_term
-      [|"name"; "configure"; "--xyz"; "--verbose"; "--no-opam"|]
+      [|"name"; "configure"; "--xyz"; "--verbose"|]
   in
   assert_equal
-    (`Ok (Cmd.Configure { result = (true, false);
-                          no_opam = true;
-                          no_opam_version = false;
-                          no_depext = false }))
+    (`Ok (Cmd.Configure { result = (true, false) }))
     result
 
 

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -35,7 +35,7 @@ let test_configure _ =
       [|"name"; "configure"; "--xyz"; "--verbose"|]
   in
   assert_equal
-    (`Ok (Cmd.Configure { result = (true, false) }))
+    (`Ok (Cmd.Configure (true, false)))
     result
 
 


### PR DESCRIPTION
I played around a bit... so instead of having `~packages:string list ~libraries:string list`, why not have a `Package.t` type and use that (``package : ?ocamlfind:[ `Prefix of string list | `Full of string list ] -> ?min:string -> ?max:string -> string -> t``)

turns out, it is possible... but there are layering violations in mirage (expecting that during configure phase packages are already installed).   the goal here is to just generate an `opam` file from `mirage configure`, and let someone else install dependencies before invoking `make`

see https://github.com/mirage/mirage/pull/691

feedback welcome @samoht @Drup @yomimono @avsm 