### PR TITLE
Rewrite configuration caching.

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -717,7 +717,11 @@ module Make (P: S) = struct
          Config'.eval ~with_required:true ~partial:false context config
        and describe =
          let context = Cache.merge ~cache:cached_context context in
-         let partial = not (full_eval || Cache.present cached_context) in
+         let partial = match full_eval with
+           | Some true  -> false
+           | Some false -> true
+           | None -> not (Cache.present cached_context)
+         in
          Config'.eval ~with_required:false ~partial context config
        and build =
          Config'.eval_cached ~partial:false cached_context config

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -49,10 +49,18 @@ let term_info title ~doc ~man ~arg =
 
 (** Argument specification for --eval *)
 let full_eval =
-  mk_flag ["eval"]
-    "Fully evaluate the graph before showing it. \
-     By default, only the keys that are given on the command line are \
-     evaluated."
+  let eval_doc =
+    Arg.info ~docs:global_option_section ["eval"]
+    ~doc:"Fully evaluate the graph before showing it. \
+          The default when the unikernel has already been configured."
+  in
+  let no_eval_doc =
+    Arg.info ~docs:global_option_section ["no-eval"]
+    ~doc:"Do not evaluate the graph before showing it. See ${b,--eval}. \
+          The default when the unikernel has not been configured."
+  in
+  let eval_opts = [ (Some true, eval_doc) ; (Some false, no_eval_doc) ] in
+  Arg.(value & vflag None eval_opts)
 
 (** Argument specification for --dot *)
 let dot =
@@ -236,10 +244,10 @@ let read_config_file : string array -> string option =
     | _, `Ok config -> config
     | _ -> None
 
-let read_full_eval : string array -> bool =
+let read_full_eval : string array -> bool option =
   fun argv -> match Term.eval_peek_opts ~argv full_eval with
     | _, `Ok b -> b
-    | _ -> false
+    | _ -> None
 
 let parse_args ~name ~version ~configure ~describe ~build ~clean ~help argv =
   Cmdliner.Term.eval_choice ~argv ~catch:false (Subcommands.default ~name ~version) [

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -22,9 +22,9 @@ val read_config_file : string array -> string option
 
 val setup_log : unit Cmdliner.Term.t
 
-val read_full_eval : string array -> bool
+val read_full_eval : string array -> bool option
 (** [read_full_eval argv] reads the --eval option from [argv]; the return
-    value indicates whether the option is present in [argv]. *)
+    value is [None] if option is absent in [argv]. *)
 
 type 'a describe_args = {
   result: 'a;

--- a/lib/functoria_key.ml
+++ b/lib/functoria_key.ml
@@ -261,6 +261,7 @@ let filter_stage stage s = match stage with
 
 type context = Univ.t
 let empty_context = Univ.empty
+let merge_context = Univ.merge
 
 let get (type a) ctx (t : a key) : a =
   match t.arg.Arg.kind, Univ.find t.key ctx with
@@ -375,7 +376,7 @@ let context ?(stage=`Both) ~with_required l =
     let f v p = Alias.apply v k.setters (Univ.add k.key v p) in
     Cmdliner.Term.(parse_key ~with_required k f $ rest)
   in
-  Set.fold gather (filter_stage stage l) (Cmdliner.Term.pure Univ.empty)
+  Set.fold gather (filter_stage stage l) (Cmdliner.Term.pure empty_context)
 
 (* {2 Code emission} *)
 

--- a/lib/functoria_key.mli
+++ b/lib/functoria_key.mli
@@ -250,6 +250,8 @@ type context
 
 val empty_context : context
 
+val merge_context : default:context -> context -> context
+
 val context:
   ?stage:Arg.stage -> with_required: bool ->
   Set.t -> context Cmdliner.Term.t

--- a/lib/functoria_misc.ml
+++ b/lib/functoria_misc.ml
@@ -134,4 +134,8 @@ module Univ = struct
   let find (kn, _kput, kget) t =
     if Map.mem kn t then Some (kget @@ Map.find kn t)
     else None
+
+  let merge ~default m =
+    let aux _k _def v = Some v in
+    Map.union aux default m 
 end

--- a/lib/functoria_misc.mli
+++ b/lib/functoria_misc.mli
@@ -53,4 +53,5 @@ module Univ: sig
   val add: 'a key -> 'a -> t -> t
   val mem: 'a key -> t -> bool
   val find: 'a key -> t -> 'a option
+  val merge: default:t -> t -> t
 end

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -162,14 +162,26 @@ let test_read_config_file _ =
 
 let test_read_full_eval _ =
   begin
-    assert_equal false
+    assert_equal None
       (Cmd.read_full_eval [|"test"|]);
 
-    assert_equal true
+    assert_equal (Some true)
       (Cmd.read_full_eval [|"test"; "--eval"|]);
 
-    assert_equal true
+    assert_equal (Some true)
       (Cmd.read_full_eval [|"test"; "blah"; "--eval"; "blah"|]);
+
+    assert_equal (Some false)
+      (Cmd.read_full_eval [|"test"; "--no-eval"|]);
+
+    assert_equal (Some false)
+      (Cmd.read_full_eval [|"test"; "blah"; "--no-eval"; "blah"|]);
+
+    assert_equal (Some true)
+      (Cmd.read_full_eval [|"--no-eval"; "test"; "--eval"|]);
+
+    assert_equal (Some false)
+      (Cmd.read_full_eval [|"--eval"; "test"; "--no-eval"|]);
   end
 
 


### PR DESCRIPTION
Sorry @hannesm, but the original implementation was not reasonable.
In theory, I would prefer to serialize a `Key.context`, but that might be tricky (univ map with exceptions .. I reckon @samoht had issues with that). If we can find a solution, I'll switch to that.

Failure modes should be decent:
- build and clean fails when cache is not present. They don't take any extra arguments
- describe can run without cached conf. If there is a cached conf, it will behave as with --eval. You can still pass extra arguments to see a different configuration.
- configure ignores the cache.