### PR TITLE
ocamlify opam filenames

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -352,6 +352,7 @@ module Config = struct
 
   let make ?(keys=[]) ?(packages=[]) ?(init=[]) name root
       main_dev =
+    let name = Name.ocamlify name in
     let jobs = Graph.create main_dev in
     let packages = Key.pure @@ packages in
     let keys = Key.Set.(union (of_list keys) (get_if_context jobs)) in

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -179,7 +179,7 @@ module Info = struct
         (pp_packages ?surround:None ~sep:(Fmt.unit ",@ ")) t
 
   let opam ?name ppf t =
-    let name = match name with None -> t.name | Some x -> x in
+    let name = (match name with None -> t.name | Some x -> x) |> Name.ocamlify in
     Fmt.pf ppf "opam-version: \"1.2\"@." ;
     Fmt.pf ppf "name: \"%s\"@." name ;
     Fmt.pf ppf "depends: [ @[<hv>%a@]@ ]@."


### PR DESCRIPTION
Users may call `register` with a name that includes characters that will
be surprising to `opam` (for example, ".").  Use `ocamlify` to restrict
the character set that will be emitted.