### PR TITLE
restrict -f command line argument to file in cwd

### DIFF
--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -16,7 +16,7 @@
 
 (** Functions for reading various options from a command line. *)
 
-val read_config_file : string array -> Fpath.t option
+val read_config_file : string array -> Fpath.t
 (** [read_config_file argv] reads the -f or --file option from [argv] and
     returns the argument of the option. *)
 

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -53,7 +53,7 @@ let test_describe _ =
       ~build:extra_term
       ~clean:extra_term
       ~help:extra_term
-      [|"name"; "describe"; "--cde"; "--file=tests/config.ml";
+      [|"name"; "describe"; "--cde";
         "--color=always"; "--dot-command=dot"; "--eval"|]
   in
   assert_equal
@@ -143,20 +143,23 @@ let test_default _ =
 
 let test_read_config_file _ =
   begin
-    assert_equal None
-      (Cmd.read_config_file [|"test"|]);
+    assert_raises ~msg:"expected: cannot find test"
+      (Invalid_argument "config must be an existing file (single segment)")
+      (fun () -> Cmd.read_config_file [|"test"|]);
 
-    assert_equal (Some (Fpath.v "tests/config.ml"))
-      (Cmd.read_config_file [|"test"; "blah"; "-f"; "tests/config.ml"|]);
+    assert_raises
+      ~msg:"expected: must be single segment"
+      (Invalid_argument "config must be an existing file (single segment)")
+      (fun () -> Cmd.read_config_file [|"test"; "blah"; "-f"; "tests/config.ml"|]);
 
-    assert_equal (Some (Fpath.v "tests/config.ml"))
-      (Cmd.read_config_file [|"test"; "blah"; "--file=tests/config.ml"|]);
+    assert_equal (Fpath.v "CHANGES.md")
+      (Cmd.read_config_file [|"test"; "blah"; "--file=CHANGES.md"|]);
 
-    assert_equal (Some (Fpath.v "tests/config.ml"))
-      (Cmd.read_config_file [|"test"; "-f"; "tests/config.ml"; "blah"|]);
+    assert_equal (Fpath.v "CHANGES.md")
+      (Cmd.read_config_file [|"test"; "-f"; "CHANGES.md"; "blah"|]);
 
-    assert_equal (Some (Fpath.v "tests/config.ml"))
-      (Cmd.read_config_file [|"test"; "--file=tests/config.ml"|]);
+    assert_equal (Fpath.v "CHANGES.md")
+      (Cmd.read_config_file [|"test"; "--file=CHANGES.md"|]);
   end
 
 


### PR DESCRIPTION
reducing complexity, making mirage and functoria slightly less flexible... now, `config.ml` is required, rather than any ML file and passing `-f`.