### PR TITLE
invoke ocamlbuild with quiet

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -570,10 +570,10 @@ module Make (P: S) = struct
       (fun () ->
          let cmd =
            Bos.Cmd.(v "ocamlbuild" % "-use-ocamlfind" % "-classic-display" %
-                    "-tags" % "bin_annot,color(always)" %
+                    "-tags" % "bin_annot,color(always)" % "-quiet" %
                     "-X" % "_build-ukvm" % "-pkg" % P.name % file)
          in
-         Bos.OS.Cmd.(run_out cmd |> to_null) >>= fun _ ->
+         Bos.OS.Cmd.run cmd >>= fun _ ->
          try Ok (Dynlink.loadfile Fpath.(to_string (root / "_build" / file)))
          with Dynlink.Error err ->
            Log.err (fun m -> m "Error loading config: %s" (Dynlink.error_message err));


### PR DESCRIPTION
addresses #86, before (with a broken `config.ml`):
```
# mirage configure
Fatal error: exception (Invalid_argument
   "run ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-tags'\
  \n     'bin_annot,color(always)' '-X' '_build-ukvm' '-pkg' 'mirage'\
  \n     'config.cmxs']: exited with 10")
```

after:
```
# mirage configure
+ ocamlfind ocamldep -package mirage -modules config.ml > config.ml.depends
File "config.ml", line 48, characters 0-1:
Error: Syntax error
Command exited with code 2.
Fatal error: exception (Invalid_argument
   "run ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-tags'\
  \n     'bin_annot,color(always)' '-quiet' '-X' '_build-ukvm' '-pkg' 'mirage'\
  \n     'config.cmxs']: exited with 10")
```

and with a good `config.ml`:
```
# mirage configure
#
```