### PR TITLE
fix commandline without --file

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -647,16 +647,16 @@ module Make (P: S) = struct
 
   let run_with_argv argv =
     let module Cmd = Functoria_command_line in
-    (* 1. Pre-parse the arguments to load the config file, set the log
-     *    level, and determine whether the graph should be fully
-     *    evaluated. *)
+    (* 1. (a) Pre-parse the arguments set the log level. *)
     ignore (Cmdliner.Term.eval_peek_opts ~argv Cmd.setup_log);
 
-    (*    (c) whether to fully evaluate the graph *)
+    (*    (b) whether to fully evaluate the graph *)
     let full_eval = Cmd.read_full_eval argv in
 
-    (*    (d) the config file passed as argument, if any *)
-    set_config_file (Cmd.read_config_file argv) ;
+    (*    (c) the config file passed as argument, if any *)
+    (match Cmd.read_config_file argv with
+     | None -> ()
+     | Some cfg -> set_config_file cfg);
 
     (* 2. Load the config from the config file. *)
     (* There are three possible outcomes:

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -591,7 +591,7 @@ module Make (P: S) = struct
       let err = Dynlink.error_message err in
       let msg = Printf.sprintf
           "error %s while loading configuration, please run 'configure' \
-           subcommand (see '%s configure --help' for details)" err P.name
+           subcommand (see '%s help configure' for details)" err P.name
       in
       Error (`Msg msg)
 

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -228,9 +228,8 @@ struct
            `P "The $(mname) application builder. It glues together a set of \
                libraries and configuration (e.g. network and storage) into a \
                standalone unikernel or UNIX binary.";
-           `P "Use either $(b,$(mname) <command> --help) or \
-               $(b,($mname) help <command>) for more information on a specific \
-               command.";
+           `P "Use $(b,($mname) help <command>) for more information on a \
+               specific command.";
          ] @  help_sections))
 end
 

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -17,8 +17,7 @@
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level level;
-  Logs.set_reporter (Logs_fmt.reporter ());
-  ()
+  Logs.set_reporter (Logs_fmt.reporter ())
 
 open Cmdliner
 

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -238,14 +238,14 @@ end
 (*
  * Functions for extracting particular flags from the command line.
  *)
-let read_config_file : string array -> Fpath.t =
+let read_config_file : string array -> Fpath.t option =
   fun argv -> match Term.eval_peek_opts ~argv config_file with
-    | _, `Ok config ->
-      if Sys.file_exists config && not (Sys.is_directory config) && Fpath.is_seg config then
-        Fpath.v config
+    | _, `Ok config when Fpath.is_seg config ->
+      if Sys.file_exists config && not (Sys.is_directory config) then
+        Some (Fpath.v config)
       else
-        invalid_arg "config must be an existing file (single segment)"
-    | _ -> invalid_arg "parse error while parsing command line"
+        None
+    | _ -> invalid_arg "config must be an existing file (single segment)"
 
 let read_full_eval : string array -> bool option =
   fun argv -> match Term.eval_peek_opts ~argv full_eval with

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -204,7 +204,7 @@ struct
         | `Error e -> `Error (false, e)
         | `Ok t when t = "topics" -> List.iter print_endline cmds; `Ok ()
         | `Ok t -> `Help (man_format, Some t) in
-    (Term.(const (fun _ () -> Help) $ setup_log $
+    (Term.(const (fun _ _ () -> Help) $ setup_log $ config_file $
            ret (Term.(const help $ Term.man_format $ Term.choice_names
                       $ topic $ base_context))),
      Term.info "help"

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -16,7 +16,7 @@
 
 (** Functions for reading various options from a command line. *)
 
-val read_config_file : string array -> Fpath.t
+val read_config_file : string array -> Fpath.t option
 (** [read_config_file argv] reads the -f or --file option from [argv] and
     returns the argument of the option. *)
 

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -143,22 +143,20 @@ let test_default _ =
 
 let test_read_config_file _ =
   begin
-    assert_raises ~msg:"expected: cannot find test"
-      (Invalid_argument "config must be an existing file (single segment)")
-      (fun () -> Cmd.read_config_file [|"test"|]);
+    assert_equal None (Cmd.read_config_file [|"test"|]);
 
     assert_raises
       ~msg:"expected: must be single segment"
       (Invalid_argument "config must be an existing file (single segment)")
       (fun () -> Cmd.read_config_file [|"test"; "blah"; "-f"; "tests/config.ml"|]);
 
-    assert_equal (Fpath.v "CHANGES.md")
+    assert_equal (Some (Fpath.v "CHANGES.md"))
       (Cmd.read_config_file [|"test"; "blah"; "--file=CHANGES.md"|]);
 
-    assert_equal (Fpath.v "CHANGES.md")
+    assert_equal (Some (Fpath.v "CHANGES.md"))
       (Cmd.read_config_file [|"test"; "-f"; "CHANGES.md"; "blah"|]);
 
-    assert_equal (Fpath.v "CHANGES.md")
+    assert_equal (Some (Fpath.v "CHANGES.md"))
       (Cmd.read_config_file [|"test"; "--file=CHANGES.md"|]);
   end
 


### PR DESCRIPTION
if we run mirage without the --file option, `config_file` will be "config.ml"
(which may be non-existing).  Deal with this situation properly.  Still error
out (invalid_arg) if called with a full path (instead of a single segment).

fix mirage with no config file commandline option