### PR TITLE
Do not error on `mirage configure --help`

### DIFF
--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -243,6 +243,7 @@ let read_config_file : string array -> Fpath.t option =
         Some (Fpath.v config)
       else
         None
+    | _, `Help -> None
     | _ -> invalid_arg "config must be an existing file (single segment)"
 
 let read_full_eval : string array -> bool option =


### PR DESCRIPTION
This prevents `mirage configure --help` raising an exception
on the CLI. However, it does not parse the config.ml, so the extra
fields only show up if `mirage help configure` is used.  That's not
ideal...