### PR TITLE
remove possibility to pass `-f <config>` to functoria.

### DIFF
--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -16,10 +16,6 @@
 
 (** Functions for reading various options from a command line. *)
 
-val read_config_file : string array -> Fpath.t option
-(** [read_config_file argv] reads the -f or --file option from [argv] and
-    returns the argument of the option. *)
-
 val setup_log : unit Cmdliner.Term.t
 
 val read_full_eval : string array -> bool option
@@ -65,23 +61,19 @@ val parse_args : name:string -> version:string ->
 
       name configure [-v|--verbose]
                      [--color=(auto|always|never)]
-                     [-f FILE | --file=FILE]
                      [extra arguments]
       name describe [--eval]
                     [-v|--verbose]
                     [--color=(auto|always|never)]
-                    [-f FILE | --file=FILE]
                     [-o FILE | --output=FILE]
                     [--dot-command=COMMAND]
                     [--dot]
                     [extra arguments]
       name build [-v|--verbose]
                  [--color=(auto|always|never)]
-                 [-f FILE | --file=FILE]
                  [extra arguments]
       name clean [-v|--verbose]
                  [--color=(auto|always|never)]
-                 [-f FILE | --file=FILE]
                  [extra arguments]
       name help [-v|--verbose]
                 [--color=(auto|always|never)]

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -141,26 +141,6 @@ let test_default _ =
   assert_equal `Help result
 
 
-let test_read_config_file _ =
-  begin
-    assert_equal None (Cmd.read_config_file [|"test"|]);
-
-    assert_raises
-      ~msg:"expected: must be single segment"
-      (Invalid_argument "config must be an existing file (single segment)")
-      (fun () -> Cmd.read_config_file [|"test"; "blah"; "-f"; "tests/config.ml"|]);
-
-    assert_equal (Some (Fpath.v "CHANGES.md"))
-      (Cmd.read_config_file [|"test"; "blah"; "--file=CHANGES.md"|]);
-
-    assert_equal (Some (Fpath.v "CHANGES.md"))
-      (Cmd.read_config_file [|"test"; "-f"; "CHANGES.md"; "blah"|]);
-
-    assert_equal (Some (Fpath.v "CHANGES.md"))
-      (Cmd.read_config_file [|"test"; "--file=CHANGES.md"|]);
-  end
-
-
 let test_read_full_eval _ =
   begin
     assert_equal None
@@ -187,10 +167,7 @@ let test_read_full_eval _ =
 
 
 let suite = "Command-line parsing tests" >:::
-  ["read_config_file"
-    >:: test_read_config_file;
-
-   "read_full_eval"
+  ["read_full_eval"
     >:: test_read_full_eval;
 
     "configure"


### PR DESCRIPTION
this lets `mirage help configure` and `mirage configure --help` see the same
output (in contrast to the current situation).   It also simplifies argument
processing.

as most recently mentioned in #100, solves #72.  IMHO this improves first user experience a lot, but removes a degree of freedom: each unikernel has to have its configuration in `config.ml`.