### PR TITLE
raise an exception with useful info when Univ.new_key fails

### DIFF
--- a/lib/functoria_misc.ml
+++ b/lib/functoria_misc.ml
@@ -116,7 +116,7 @@ module Univ = struct
       in
       ( s
       , (fun a -> M.E a)
-      , (function M.E a -> a | _ -> assert false)
+      , (function M.E a -> a | _ -> raise @@ Invalid_argument ("duplicate key: " ^ s))
       )
 
   module Map = Map.Make(String)


### PR DESCRIPTION
The absolute easiest possible thing to make https://github.com/mirage/mirage/issues/786 less bad.