### PR TITLE
Generate smaller, simpler code

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -42,7 +42,7 @@ let sys_argv = impl @@ object
     method ty = argv
     method name = "argv"
     method module_name = "Sys"
-    method !connect _info _m _ = `Eff "return Sys.argv"
+    method !connect _info _m _ = `Val "Sys.argv"
   end
 
 let src = Logs.Src.create "functoria" ~doc:"functoria library"
@@ -142,7 +142,7 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
     val file = Fpath.(v (String.Ascii.lowercase gen_modname) + "ml")
     method module_name = gen_modname
     method !packages = Key.pure [package "functoria-runtime"]
-    method !connect _ modname _ = `Eff (Fmt.strf "return %s.info" modname)
+    method !connect _ modname _ = `Val (Fmt.strf "%s.info" modname)
 
     method !clean _i =
       Bos.OS.Path.delete file >>= fun () ->
@@ -288,7 +288,7 @@ module Engine = struct
       Fmt.(list ~sep:nop bind) rnames
       (match connect_string rnames with
        | `Eff e -> e
-       | `Val e -> e)
+       | `Val v -> Fmt.strf "return (%s)" v)
 
   let emit_run init main =
     (* "exit 1" is ok in this code, since cmdliner will print help. *)

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -286,7 +286,9 @@ module Engine = struct
       iname
       Fmt.(list ~sep:nop meta_init) (List.combine names rnames)
       Fmt.(list ~sep:nop bind) rnames
-      (let `Eff e = connect_string rnames in e)
+      (match connect_string rnames with
+       | `Eff e -> e
+       | `Val e -> e)
 
   let emit_run init main =
     (* "exit 1" is ok in this code, since cmdliner will print help. *)

--- a/app/functoria_graph.ml
+++ b/app/functoria_graph.ml
@@ -48,7 +48,8 @@ type subconf = <
   module_name: string;
   keys: Key.t list;
   packages: package list Key.value;
-  connect: Info.t -> string -> string list -> [`Eff of string];
+  connect: Info.t -> string -> string list -> [`Eff of string
+                                              |`Val of string];
   build: Info.t -> (unit, Rresult.R.msg) result;
   configure: Info.t -> (unit, Rresult.R.msg) result;
   clean: Info.t -> (unit, Rresult.R.msg) result;

--- a/app/functoria_graph.ml
+++ b/app/functoria_graph.ml
@@ -48,7 +48,7 @@ type subconf = <
   module_name: string;
   keys: Key.t list;
   packages: package list Key.value;
-  connect: Info.t -> string -> string list -> string;
+  connect: Info.t -> string -> string list -> [`Eff of string];
   build: Info.t -> (unit, Rresult.R.msg) result;
   configure: Info.t -> (unit, Rresult.R.msg) result;
   clean: Info.t -> (unit, Rresult.R.msg) result;

--- a/app/functoria_graph.mli
+++ b/app/functoria_graph.mli
@@ -23,7 +23,8 @@ type subconf = <
   module_name: string;
   keys       : key list;
   packages   : package list value ;
-  connect    : Info.t -> string -> string list -> [`Eff of string];
+  connect    : Info.t -> string -> string list -> [`Eff of string
+                                                  |`Val of string];
   build      : Info.t -> (unit, Rresult.R.msg) result;
   configure  : Info.t -> (unit, Rresult.R.msg) result;
   clean      : Info.t -> (unit, Rresult.R.msg) result;

--- a/app/functoria_graph.mli
+++ b/app/functoria_graph.mli
@@ -23,7 +23,7 @@ type subconf = <
   module_name: string;
   keys       : key list;
   packages   : package list value ;
-  connect    : Info.t -> string -> string list -> string;
+  connect    : Info.t -> string -> string list -> [`Eff of string];
   build      : Info.t -> (unit, Rresult.R.msg) result;
   configure  : Info.t -> (unit, Rresult.R.msg) result;
   clean      : Info.t -> (unit, Rresult.R.msg) result;

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -224,7 +224,7 @@ module rec Typ: sig
     method module_name: string
     method keys: Key.t list
     method packages: package list Key.value
-    method connect: Info.t -> string -> string list -> string
+    method connect: Info.t -> string -> string list -> [`Eff of string]
     method configure: Info.t -> (unit, R.msg) R.t
     method build: Info.t -> (unit, R.msg) R.t
     method clean: Info.t -> (unit, R.msg) R.t
@@ -248,7 +248,8 @@ class base_configurable = object
   method packages: package list Key.value = Key.pure []
   method keys: Key.t list = []
   method connect (_:Info.t) (_:string) l =
-    Printf.sprintf "return (%s)" (String.concat ~sep:", " l)
+    (`Eff (Printf.sprintf "return (%s)" (String.concat ~sep:", " l))
+        : [`Eff of string])
   method configure (_: Info.t): (unit, R.msg) R.t = R.ok ()
   method build (_: Info.t): (unit, R.msg) R.t = R.ok ()
   method clean (_: Info.t): (unit, R.msg) R.t = R.ok ()
@@ -270,10 +271,11 @@ class ['ty] foreign
     method keys = keys
     method packages = Key.pure packages
     method connect _ modname args =
-      Fmt.strf
-        "@[%s.start@ %a@]"
-        modname
-        Fmt.(list ~sep:sp string)  args
+      `Eff
+        (Fmt.strf
+           "@[%s.start@ %a@]"
+           modname
+           Fmt.(list ~sep:sp string)  args)
     method clean _ = R.ok ()
     method configure _ = R.ok ()
     method build _ = R.ok ()

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -224,7 +224,8 @@ module rec Typ: sig
     method module_name: string
     method keys: Key.t list
     method packages: package list Key.value
-    method connect: Info.t -> string -> string list -> [`Eff of string]
+    method connect: Info.t -> string -> string list -> [`Eff of string
+                                                       |`Val of string]
     method configure: Info.t -> (unit, R.msg) R.t
     method build: Info.t -> (unit, R.msg) R.t
     method clean: Info.t -> (unit, R.msg) R.t
@@ -249,7 +250,8 @@ class base_configurable = object
   method keys: Key.t list = []
   method connect (_:Info.t) (_:string) l =
     (`Eff (Printf.sprintf "return (%s)" (String.concat ~sep:", " l))
-        : [`Eff of string])
+        : [`Eff of string
+          |`Val of string])
   method configure (_: Info.t): (unit, R.msg) R.t = R.ok ()
   method build (_: Info.t): (unit, R.msg) R.t = R.ok ()
   method clean (_: Info.t): (unit, R.msg) R.t = R.ok ()

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -249,9 +249,10 @@ class base_configurable = object
   method packages: package list Key.value = Key.pure []
   method keys: Key.t list = []
   method connect (_:Info.t) (_:string) l =
-    (`Eff (Printf.sprintf "return (%s)" (String.concat ~sep:", " l))
-        : [`Eff of string
-          |`Val of string])
+    (* The `Val here assumes that the expressions in `l` are pure *)
+    (`Val (Printf.sprintf "(%s)" (String.concat ~sep:", " l))
+     : [`Eff of string
+       |`Val of string])
   method configure (_: Info.t): (unit, R.msg) R.t = R.ok ()
   method build (_: Info.t): (unit, R.msg) R.t = R.ok ()
   method clean (_: Info.t): (unit, R.msg) R.t = R.ok ()

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -254,7 +254,7 @@ class type ['ty] configurable = object
   (** [packages] is the list of OPAM packages which needs to be
       installed before compiling the configurable. *)
 
-  method connect: Info.t -> string -> string list -> string
+  method connect: Info.t -> string -> string list -> [`Eff of string]
   (** [connect info mod args] is the code to execute in order to
       initialize the state associated with the module [mod] (usually
       calling [mod.connect]) with the arguments [args], in the context
@@ -307,7 +307,7 @@ val impl: 'a configurable -> 'a impl
 class base_configurable: object
   method packages: package list value
   method keys: key list
-  method connect: Info.t -> string -> string list -> string
+  method connect: Info.t -> string -> string list -> [`Eff of string]
   method configure: Info.t -> (unit, Rresult.R.msg) result
   method build: Info.t -> (unit, Rresult.R.msg) result
   method clean: Info.t -> (unit, Rresult.R.msg) result

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -254,7 +254,8 @@ class type ['ty] configurable = object
   (** [packages] is the list of OPAM packages which needs to be
       installed before compiling the configurable. *)
 
-  method connect: Info.t -> string -> string list -> [`Eff of string]
+  method connect: Info.t -> string -> string list -> [`Eff of string
+                                                     |`Val of string]
   (** [connect info mod args] is the code to execute in order to
       initialize the state associated with the module [mod] (usually
       calling [mod.connect]) with the arguments [args], in the context
@@ -307,7 +308,8 @@ val impl: 'a configurable -> 'a impl
 class base_configurable: object
   method packages: package list value
   method keys: key list
-  method connect: Info.t -> string -> string list -> [`Eff of string]
+  method connect: Info.t -> string -> string list -> [`Eff of string
+                                                     |`Val of string]
   method configure: Info.t -> (unit, Rresult.R.msg) result
   method build: Info.t -> (unit, Rresult.R.msg) result
   method clean: Info.t -> (unit, Rresult.R.msg) result

--- a/tests/lib/test_app.ml
+++ b/tests/lib/test_app.ml
@@ -65,7 +65,7 @@ module C = struct
       method ty = Functoria.job
       method name = "test_app"
       method module_name = "Test_app"
-      method! connect _ _ _ = "()"
+      method! connect _ _ _ = `Val "()"
       method! keys = [
         Functoria_key.(abstract vote);
         Functoria_key.(abstract warn_error);


### PR DESCRIPTION
This PR makes a few changes to the code generated by functoria to make it smaller and simpler.  The aims are readability and simplicity, not performance, but there might be some small performance improvements.

The typical space savings are around 40-45%.  For example,
 * the `main.ml` file for [`conduit_server`][conduit-server] drops from 199 lines to 115 lines
 * the `main.ml` file for [`console`][console] drops from 80 lines to 43 lines

The code is simplified/shrunk in three main ways:

1. First, there's a distinction between between effectful and non-effectful initialization code in the return type of `connect`.  (This is perhaps a first step in the direction of generating code at a slightly higher level than string concatenation.)

   The implementer of `connect` tags the generated code with `Val` or `Eff` according to whether it's a simple value or a possibly-effectful computation, and the caller of `connect` uses the tag to determine whether the value can be safely inlined.  For effectful computations the generated code follows the previous scheme: a top-level binding is emitted
   
   ```ocaml
   let name = lazy (connect_code ())
   ```

   which is used in `connect` code for other modules:

   ```ocaml
   name >>= fun _name ->
   ...
   return (f ... _name ...)
   ```

   For effect-free computations the top-level binding is omitted and the value is instead inlined directly:

   ```ocaml
   ...
   return (f ... connect_value ...)
   ```

2. Second, the code that forces lazy values and the code that executes the resulting `Lwt` computations are combined, avoiding an intermediate binding.  Before:

   ```ocaml   
   let __foo = Lazy.force foo in
   __foo >>= fun _foo ->
   ...
   ```   
   After:
   ```ocaml   
   Lazy.force foo >>= fun _foo ->
   ...
   ```   
   (This changes evaluation order slightly, so it would be a good idea for someone to confirm that the change is safe.)

3. Finally, the layout is now a little more compact.  For example, short expressions now occupy a single line.  Before:

   ```ocaml
   let foo = lazy (
     M.connect ()
    )
   ```
   After:
   ```ocaml
   let foo = lazy ( M.connect ())
   ```

[conduit-server]: https://github.com/mirage/mirage-skeleton/blob/master/conduit_server/config.ml
[console]: https://github.com/mirage/mirage-skeleton/blob/master/console/config.ml
