### PR TITLE
Add a --output option to configure

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -397,6 +397,7 @@ module Cache : sig
   val clean : Fpath.t -> (unit, [> Rresult.R.msg ]) result
   val get_context : Fpath.t -> context Term.t ->
     [> `Error of bool * string | `Ok of context option ]
+  val get_output: Fpath.t -> [> `Error of bool * string | `Ok of string option ]
   val require :
     [< `Error of bool * string | `Ok of context option ] -> context Term.ret
   val merge :
@@ -434,6 +435,13 @@ end = struct
           "Invalid cached configuration. Please run configure again."
         in
         `Error (false, msg)
+
+  let get_output root =
+    match get_context root Functoria_command_line.output with
+    | `Ok (Some None) -> `Ok None
+    | `Ok (Some x)    -> `Ok x
+    | `Ok None        -> `Ok None
+    | `Error e        -> `Error e
 
   let require cache : _ Cmdliner.Term.ret =
     match cache with
@@ -506,7 +514,7 @@ module Make (P: S) = struct
 
   let configure i jobs =
     Log.info (fun m -> m "Using configuration: %a" Fpath.pp config_file);
-    Log.info (fun m -> m "opam: %a" (Info.opam ?name:None) i);
+    Log.info (fun m -> m "output: %a" Fmt.(option string) (Info.output i));
     Log.info (fun m -> m "within: %a" Fpath.pp (Info.root i));
     with_current
       (Info.root i)
@@ -634,11 +642,16 @@ module Make (P: S) = struct
       print_newline ();
       exit 1
 
+  let with_output i = function
+    | None   -> i
+    | Some o -> Info.with_output i o
+
   let handle_parse_args_result = let module Cmd = Functoria_command_line in
     function
     | `Error _ -> exit 1
     | `Ok Cmd.Help -> ()
-    | `Ok (Cmd.Configure (jobs, info)) ->
+    | `Ok (Cmd.Configure { result = (jobs, info); output }) ->
+      let info = with_output info output in
       Log.info (fun m -> Config'.pp_info m (Some Logs.Debug) info);
       exit_err (configure info jobs)
     | `Ok (Cmd.Build (jobs, info)) ->
@@ -697,6 +710,14 @@ module Make (P: S) = struct
         in
 
         let cached_context = Cache.get_context config.root context_args in
+        let merge_output term =
+          match Cache.get_output config.root with
+          | `Ok (Some o) ->
+            let update_output (r, i) = r, Info.with_output i o in
+            Cmdliner.Term.(app (const update_output) term)
+          | _ -> term
+        in
+
         let context =
           match Cmdliner.Term.eval_peek_opts ~argv context_args with
           | _, `Ok context -> context
@@ -717,8 +738,10 @@ module Make (P: S) = struct
           Config'.eval ~with_required:false ~partial context config
         and build =
           Config'.eval_cached ~partial:false cached_context config
+          |> merge_output
         and clean =
           Config'.eval_cached ~partial:false cached_context config
+          |> merge_output
         in
 
         handle_parse_args_result

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -81,7 +81,7 @@ let dotcmd =
 let output =
   let doc =
     Arg.info ~docs:global_option_section ~docv:"FILE" ["o"; "output"]
-      ~doc:"File where to output description or dot representation."
+      ~doc:"Name of the output file."
   in
   Arg.(value & opt (some string) None & doc)
 
@@ -92,8 +92,13 @@ type 'a describe_args = {
   output: string option;
 }
 
+type 'a configure_args = {
+  result: 'a;
+  output: string option;
+}
+
 type 'a action =
-    Configure of 'a
+    Configure of 'a configure_args
   | Describe of 'a describe_args
   | Build of 'a
   | Clean of 'a
@@ -112,8 +117,9 @@ struct
         `S "DESCRIPTION";
         `P "The $(b,configure) command initializes a fresh $(mname) application."
       ]
-      ~arg:Term.(const (fun _ info -> Configure info)
+      ~arg:Term.(const (fun _ output result -> Configure { output; result })
                  $ setup_log
+                 $ output
                  $ result)
 
   (** The 'describe' subcommand *)

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -17,10 +17,18 @@
 (** Functions for reading various options from a command line. *)
 
 val setup_log : unit Cmdliner.Term.t
+val output: string option Cmdliner.Term.t
 
 val read_full_eval : string array -> bool option
 (** [read_full_eval argv] reads the --eval option from [argv]; the return
     value is [None] if option is absent in [argv]. *)
+
+type 'a configure_args = {
+  result: 'a;
+  output: string option;
+}
+(** A value of type [configure_args] is the result of parsing the arguments of
+    a [configure] subcommand. *)
 
 type 'a describe_args = {
   result: 'a;
@@ -36,7 +44,7 @@ type 'a describe_args = {
     {!parse_args}. *)
 
 type 'a action =
-    Configure of 'a
+    Configure of 'a configure_args
   | Describe of 'a describe_args
   | Build of 'a
   | Clean of 'a

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -172,6 +172,14 @@ module Info: sig
   val name: t -> string
   (** [name t] is the name of the application. *)
 
+  val output: t -> string option
+  (** [output t] is the name of [t]'s output. Derived from {!name} if
+      not set. *)
+
+  val with_output: t -> string -> t
+  (** [with_output t o] is similar to [t] but with the output set to
+      [Some o]. *)
+
   val root: t -> Fpath.t
   (** Directory in which the configuration is done. *)
 
@@ -202,9 +210,11 @@ module Info: sig
 
   val pp: bool -> t Fmt.t
 
-  val opam : ?name:string -> t Fmt.t
-  (** [opam ~name t] generates an opam file including all dependencies.  The
-      [name] will be used as package name, defaults to {!name}. *)
+  val opam: ?name:string -> t Fmt.t
+  (** [opam t] generates an opam file including all dependencies. If
+      set, [name] will be used as package name, otherwise use
+      {!name}. *)
+
 end
 
 (** Signature for configurable module implementations. A

--- a/tests/test_functoria_command_line.ml
+++ b/tests/test_functoria_command_line.ml
@@ -35,7 +35,7 @@ let test_configure _ =
       [|"name"; "configure"; "--xyz"; "--verbose"|]
   in
   assert_equal
-    (`Ok (Cmd.Configure (true, false)))
+    (`Ok (Cmd.Configure { result = (true, false); output = None }))
     result
 
 


### PR DESCRIPTION
That option is used to overwrite the name of the unikernel, eg. this
enables the workflow:

```
mirage configre -o foo
make
./foo
```