### PR TITLE
make a nicer error message for broken configs

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -572,7 +572,7 @@ module Make (P: S) = struct
            Format.fprintf Format.str_formatter "error while executing %a\n%s"
              Bos.Cmd.pp cmd out ;
            let err = Format.flush_str_formatter () in
-           Error (`Msg err))
+           Error (`Invalid_config_ml err))
       "compile configuration"
 
   (* attempt to dynlink the configuration file.
@@ -688,7 +688,8 @@ module Make (P: S) = struct
             when they weren't loaded *)
 
       match load' config_file with
-      | Error err -> handle_parse_args_no_config err argv
+      | Error (`Invalid_config_ml err) -> Logs.err (fun f -> f "%s" err)
+      | Error (`Msg _ as err) -> handle_parse_args_no_config err argv
       | Ok config ->
 
         let config_keys = Config.keys config in


### PR DESCRIPTION
When `config.ml` isn't buildable, don't tell the user that `-t` is invalid and show the help; rather, just print the output from `ocamlbuild`.

```
4.04.0🐫  ((detached from origin/master)) mirageos:~/mirage-skeleton/tutorial/hello$ echo "HI OCAML LET'S DO A NICE UNIKERNEL" >> config.ml
4.04.0🐫  ((detached from origin/master)) mirageos:~/mirage-skeleton/tutorial/hello$ mirage configure -t unix
mirage: [ERROR] error while executing ocamlbuild -use-ocamlfind -classic-display -tags
                        bin_annot -quiet -X _build-ukvm -pkg mirage
                        config.cmxs
+ ocamlfind ocamlc -c -bin-annot -package mirage -o config.cmo config.ml
File "config.ml", line 10, characters 0-2:
Error: The function applied to this argument has type
         ?argv:Functoria_app.argv Mirage.impl ->
         ?tracing:Mirage.tracing Mirage.impl ->
         ?reporter:Mirage.reporter Mirage.impl ->
         ?keys:Mirage.Key.t list -> ?packages:Functoria.package list -> unit
This argument cannot be applied without label
Command exited with code 2.
```