### PR TITLE
partially reverts 35564079: don't ocamlify the name when generating opam file

### DIFF
--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -179,7 +179,7 @@ module Info = struct
         (pp_packages ?surround:None ~sep:(Fmt.unit ",@ ")) t
 
   let opam ?name ppf t =
-    let name = (match name with None -> t.name | Some x -> x) |> Name.ocamlify in
+    let name = match name with None -> t.name | Some x -> x in
     Fmt.pf ppf "opam-version: \"1.2\"@." ;
     Fmt.pf ppf "name: \"%s\"@." name ;
     Fmt.pf ppf "depends: [ @[<hv>%a@]@ ]@."


### PR DESCRIPTION
mirage (in `configure_opam`) passes as `~name` argument:
`String.concat ~sep:"-" ["mirage";"unikernel";Info.name;target]`
(where `Info.name` is already `ocamlify`d).

`Info.opam` does another round of `ocamlify`, which results in the filename
mirage-unikernel-hello-macosx.opam which contains:
`name: "mirage_unikernel_hello_macosx"`
for no good reason, but is a source of confusion.

discovered via https://github.com/mirage/mirage/issues/809 -- //cc @yomimono (did you had any issues if only `Functoria_app.Config.make` did the `ocamlify`?