### PR TITLE
activate tests in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
   - PACKAGE=functoria
   - PINS="mirage-skeleton.dev:https://github.com/mirage/mirage-skeleton.git"
+  - TESTS=true
   matrix:
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.03
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.04

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Activate tests in Travis CI.
+
 ## 2.1.0 (03/07/2017)
 
 * port build to Jbuilder (#115 @djs55)

--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -16,9 +16,6 @@ build: [
   ["jbuilder" "subst"] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-build-test: [
-  ["jbuilder" "runtest"]
-]
 
 depends: [
   "jbuilder" {build & >="1.0+beta10"}

--- a/functoria.opam
+++ b/functoria.opam
@@ -17,7 +17,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [
-  ["jbuilder" "runtest"]
+  ["jbuilder" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta10"}


### PR DESCRIPTION
also do not run tests in the wrong package (functoria-runtime)
as that will try to run the functoria tests but not have
the deps installed