### PR TITLE
Re-add the `--config` argument to select which config file to use

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -478,12 +478,17 @@ module Make (P: S) = struct
   module Log = (val Logs.src_log src : Logs.LOG)
 
   let configuration = ref None
-  let config_file = Fpath.(v "config.ml")
+  let config_file = ref Fpath.(v "config.ml")
 
-  let get_root () =
+  let get_cwd () =
     match Bos.OS.Dir.current () with
     | Ok p -> p
     | Error e -> R.error_msg_to_invalid_arg (Error e)
+
+  let get_root () =
+    if Fpath.(is_abs !config_file) then Fpath.(parent !config_file)
+    else
+      Fpath.(get_cwd () // parent !config_file)
 
   let register ?packages ?keys ?(init=[]) name jobs =
     let root = get_root () in
@@ -516,7 +521,7 @@ module Make (P: S) = struct
     Bos.OS.File.delete Fpath.(v "main.ml")
 
   let configure ~argv i jobs =
-    Log.info (fun m -> m "Using configuration: %a" Fpath.pp config_file);
+    Log.info (fun m -> m "Using configuration: %a" Fpath.pp !config_file);
     Log.info (fun m -> m "output: %a" Fmt.(option string) (Info.output i));
     Log.info (fun m -> m "within: %a" Fpath.pp (Info.root i));
     with_current
@@ -525,14 +530,14 @@ module Make (P: S) = struct
       "configure"
 
   let build i jobs =
-    Log.info (fun m -> m "Building: %a" Fpath.pp config_file);
+    Log.info (fun m -> m "Building: %a" Fpath.pp !config_file);
     with_current
       (Info.root i)
       (fun () -> Engine.build i jobs)
       "build"
 
   let clean i (_init, job) =
-    Log.info (fun m -> m "Cleaning: %a" Fpath.pp config_file);
+    Log.info (fun m -> m "Cleaning: %a" Fpath.pp !config_file);
     with_current
       (Info.root i)
       (fun () ->
@@ -562,7 +567,7 @@ module Make (P: S) = struct
   (* Compile the configuration file. *)
   let compile file =
     Log.info (fun m -> m "Compiling: %a" Fpath.pp file);
-    let file = Dynlink.adapt_filename (Fpath.to_string file)
+    let file = Dynlink.adapt_filename (Fpath.basename file)
     and cfg = Fpath.rem_ext file
     and root = get_root ()
     in
@@ -599,15 +604,17 @@ module Make (P: S) = struct
    * [register] in order to have an observable
    * side effect to this command *)
   let dynlink file =
-    let file = Dynlink.adapt_filename (Fpath.to_string file)
+    let file = Dynlink.adapt_filename (Fpath.basename file)
     and root = get_root ()
     in
-    try Ok (Dynlink.loadfile Fpath.(to_string (root / "_build" / file)))
+    let file = Fpath.(to_string (root / "_build" / file)) in
+    try Ok (Dynlink.loadfile file)
     with Dynlink.Error err ->
       let err = Dynlink.error_message err in
       let msg = Printf.sprintf
-          "error %s while loading configuration, please run 'configure' \
-           subcommand (see '%s help configure' for details)" err P.name
+          "error %s while loading %s, please run 'configure' \
+           subcommand (see '%s help configure' for details)"
+          err file P.name
       in
       Error (`Msg msg)
 
@@ -651,6 +658,7 @@ module Make (P: S) = struct
     | Error (`Msg m) ->
       R.pp_msg Format.std_formatter (`Msg m) ;
       print_newline ();
+      flush_all ();
       exit 1
 
   let with_output i = function
@@ -697,6 +705,8 @@ module Make (P: S) = struct
   let run_with_argv ?help_ppf ?err_ppf argv =
     (* 1. (a) Pre-parse the arguments set the log level. *)
     ignore (Cmdliner.Term.eval_peek_opts ~argv Cmd.setup_log);
+    ignore (Cmdliner.Term.eval_peek_opts ~argv @@
+            Cmd.config_file (fun c -> config_file := c));
 
     (*    (b) whether to fully evaluate the graph *)
     let full_eval = Cmd.read_full_eval argv in
@@ -708,7 +718,7 @@ module Make (P: S) = struct
          3. an attempt is made to access the base keys at this point.
             when they weren't loaded *)
 
-      match load' config_file with
+      match load' !config_file with
       | Error (`Invalid_config_ml err) -> exit_err (Error (`Msg err))
       | Error (`Msg _ as err) -> handle_parse_args_no_config err argv
       | Ok config ->

--- a/app/functoria_app.mli
+++ b/app/functoria_app.mli
@@ -73,6 +73,12 @@ module type S = sig
   val name: string
   (** Name of the custom DSL. *)
 
+  val packages: string list
+  (** The packages to load when compiling the configuration file. *)
+
+  val ignore_dirs: string list
+  (** Directories to ignore when compiling the configuration file. *)
+
   val version: string
   (** Version of the custom DSL. *)
 

--- a/app/functoria_command_line.ml
+++ b/app/functoria_command_line.ml
@@ -28,6 +28,16 @@ let setup_log =
         $ Fmt_cli.style_renderer ~docs:global_option_section ()
         $ Logs_cli.level ~docs:global_option_section ())
 
+let config_file f =
+  let doc =
+    Arg.info
+      ~docv:"FILE"
+      ~doc:"The configuration file to use."
+      ["f"; "file"]
+  in
+  Term.(const (fun x ->  f (Fpath.v x))
+        $ Arg.(value & opt string "config.ml" & doc))
+
 let help_sections = [
   `S global_option_section;
   `P "These options are common to all commands.";
@@ -136,8 +146,9 @@ struct
         `S "DESCRIPTION";
         `P "The $(b,configure) command initializes a fresh $(mname) application."
       ]
-      ~arg:Term.(const (fun _ output result -> Configure { output; result })
+      ~arg:Term.(const (fun _ _ output result -> Configure { output; result })
                  $ setup_log
+                 $ config_file (fun _ -> ())
                  $ output
                  $ result)
 
@@ -165,9 +176,10 @@ struct
         `I ("App vertices",
             "Represented as diamonds. The bold arrow is the functor part.");
       ]
-      ~arg:Term.(const (fun _ _ info output dotcmd dot ->
+      ~arg:Term.(const (fun _ _ _ info output dotcmd dot ->
           Describe { result = info; dotcmd; dot; output })
                  $ setup_log
+                 $ config_file (fun _ -> ())
                  $ full_eval
                  $ result
                  $ output
@@ -182,8 +194,9 @@ struct
         `S "DESCRIPTION";
         `P doc;
       ]
-      ~arg:Term.(const (fun _ info -> Build info)
+      ~arg:Term.(const (fun _ _ info -> Build info)
                  $ setup_log
+                 $ config_file (fun _ -> ())
                  $ result)
 
   (** The 'clean' subcommand *)
@@ -194,8 +207,9 @@ struct
         `S "DESCRIPTION";
         `P doc;
       ]
-      ~arg:Term.(const (fun _ info -> Clean info)
+      ~arg:Term.(const (fun _ _ info -> Clean info)
                  $ setup_log
+                 $ config_file (fun _ -> ())
                  $ info_)
 
   (** The 'help' subcommand *)

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -18,6 +18,7 @@
 
 val setup_log : unit Cmdliner.Term.t
 val config_file : (Fpath.t -> unit) -> unit Cmdliner.Term.t
+val root: (Fpath.t -> unit) -> unit Cmdliner.Term.t
 val output: string option Cmdliner.Term.t
 
 val read_full_eval : string array -> bool option

--- a/app/functoria_command_line.mli
+++ b/app/functoria_command_line.mli
@@ -17,6 +17,7 @@
 (** Functions for reading various options from a command line. *)
 
 val setup_log : unit Cmdliner.Term.t
+val config_file : (Fpath.t -> unit) -> unit Cmdliner.Term.t
 val output: string option Cmdliner.Term.t
 
 val read_full_eval : string array -> bool option


### PR DESCRIPTION
blah --config foo/bar.ml` is the same as:

```
cd foo && cp bar.ml config.ml && blah
```

/cc @hannesm who removed the CLI argument at the first place