### PR TITLE
Add support for projections

### DIFF
--- a/app/functoria_graph.mli
+++ b/app/functoria_graph.mli
@@ -42,6 +42,7 @@ type label =
   | If of If.path value
   | Impl of subconf
   | App
+  | Proj of string
 
 module Tbl: Hashtbl.S with type key = vertex
 
@@ -81,7 +82,9 @@ val explode:
   | `If of If.path value * (If.path * vertex) list
   | `Impl of subconf
              * [> `Args of vertex list ]
-             * [> `Deps of vertex list ] ]
+             * [> `Deps of vertex list ]
+  | `PrimProj of string
+  | `Proj of string * vertex ]
 (** [explode g v] deconstructs the vertex [v] in the graph [g]
     into it's possible components.
     It also checks that the local invariants are respected. *)

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -95,6 +95,7 @@ val match_impl: 'b value -> default:'a impl -> ('b * 'a impl) list ->  'a impl
     [cases] by matching the [v]'s value. [default] is chosen if no
     value matches. *)
 
+val proj: ('a -> 'b) typ -> string -> ('a -> 'b) impl
 
 module type KEY =
   module type of Functoria_key
@@ -347,4 +348,5 @@ module ImplTbl: Hashtbl.S with type key = abstract_impl
 val explode: 'a impl ->
   [ `App of abstract_impl * abstract_impl
   | `If of bool value * 'a impl * 'a impl
-  | `Impl of 'a configurable ]
+  | `Impl of 'a configurable
+  | `Proj of string ]


### PR DESCRIPTION
This adds a new combinator:

```ocaml
val proj: ('a -> 'b) typ -> string -> ('a -> 'b) impl
```

`proj (foo @-> bar) "Bar"` should be applied to an impl of type `foo` (supporting a module `M`), returns `M.Bar` and the resulting implementation is assumed to be of type `bar`. the connect for this implementation is the identity.

The combinator (and the implementation) is somewhat raw at the moment. It is not very useful for mirage in general, but it made [functoria-lua](https://github.com/Drup/functoria-lua) much cleaner.