### PR TITLE
expose the transitive opam dependencies of a project

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -130,8 +130,8 @@ let pp_dump_pkgs module_name fmt (name, pkg, libs) =
     "%s.{@ name = %S;@ \
      @[<v 2>packages = %a@]@ ;@ @[<v 2>libraries = %a@]@ }"
     module_name name
-    pp_packages (List.sort String.compare (String.Set.elements pkg))
-    pp_libraries (List.sort String.compare (String.Set.elements libs))
+    pp_packages (String.Set.elements pkg)
+    pp_libraries (String.Set.elements libs)
 
 let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
   impl @@ object

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -94,29 +94,14 @@ module Package = struct
       invalid_arg ("invalid version constraints for " ^ opam)
     | _ -> { opam ; build ; ocamlfind ; min ; max }
 
-  let ocamlfind build p =
-    if p.build = build then
-      p.ocamlfind
-    else
-      String.Set.empty
-
   let libraries ps =
+    let ocamlfind p = if p.build then String.Set.empty else p.ocamlfind in
     String.Set.elements
       (List.fold_left String.Set.union String.Set.empty
-         (List.map (ocamlfind false) ps))
-
-  let package_name build p =
-    if p.build = build then
-      Some p.opam
-    else
-      None
+         (List.map ocamlfind ps))
 
   let package_names ps =
-    List.fold_left (fun acc p ->
-        match package_name false p with
-        | Some pack -> pack :: acc
-        | None -> acc) []
-      ps
+    List.fold_left (fun acc p -> if p.build then acc else p.opam :: acc) [] ps
 
   let exts_to_string min max build =
     let bui = if build then "build & " else "" in

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -195,16 +195,16 @@ module Info: sig
   (** Directory in which the build is done. *)
 
   val libraries: t -> string list
-  (** OCamlfind libraries needed by the project at runtime. *)
+  (** [libraries t] are the direct OCamlfind dependencies. *)
 
   val package_names: t -> string list
-  (** OPAM packages names needed by the project at runtime. *)
+  (** [package_names t] are the opam package dependencies. *)
 
   val packages: t -> package list
-  (** OPAM packages needed by the project. *)
+  (** [packages t] are the opam package dependencies by the project. *)
 
   val keys: t -> key list
-  (** Keys declared by the project. *)
+  (** [keys t] are the keys declared by the project. *)
 
   val context: t -> context
   (** [parsed t] is a value representing the command-line argument


### PR DESCRIPTION
the current state is that the explicitly named opam dependencies are gathered in `Functoria_info`.  While this is useful for building a unikernel, at runtime it is much more convenient to have a complete list of all runtime dependencies (maybe even including build time dependencies) available.  One use case is to be able to poke at a unikernel image and discover whether it needs to be updated (given a new stream of released libraries).  Another use case is to be able to reproduce a unikernel just from a binary (this requires to include `cc`, `ld`, and `as` version information - but not more AFAICT, maybe `CFLAGS` set in the environment).

The approach taken here uses `ocamlfind query -r -format %p` during build, and using `opam subst` afterwards to replace the version numbers with the installed opam packages.

Drawbacks:
- the list of opam repositories is not included (best done including the latest commit/modification -- if anyone has some `opam` command line to get this information, that'd be great -- `opam repo list` is rather incomplete and not too useful)
- the list generated by `ocamlfind` is incomplete (since it uses `ocamlfind` dependencies, as specified in `META`, which is incomplete -- e.g. there's no mention of `ocaml-freestanding` in `mirage-solo5`, `bigarray` requires `unix`, `gmp-xen`/`gmp-freestanding` don't appear in any dependency chain, and I can't find any `ocaml-src` dependencies anywhere)
- for reproducibility, build dependencies may also be crucial: a `ppx` at version X may generate different output than at version Y.  I'd prefer to separate the build and runtime dependencies though (whereas `opam list --recursive --resolve=tcpip` doesn't distinguish between the two).

Previous discussion at https://github.com/mirage/mirage/issues/896 where (a) @avsm mentions the need for the opam repositories, (b) @samoht points to https://github.com/MagnusS/mirage-stats-demo/blob/master/manifest/manifest.ml for earlier work (using `opam list -s --required-by %s --rec --depopts --installed` which includes build dependencies AFAICT), (c) @Drup suggests to use opam2: `opam list --nobuild --depopts --installed --rec --required-by <PKG>` - but I don't think that relying on opam2 is an option atm.