### PR TITLE
Expand the signature Functoria.Key manually.

### DIFF
--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -321,4 +321,14 @@ type key = Functoria_key.t
 type context = Functoria_key.context
 type 'a value = 'a Functoria_key.value
 
-module type KEY = module type of struct include Functoria_key end
+module type KEY =
+  module type of Functoria_key
+  with type 'a Arg.converter = 'a Functoria_key.Arg.converter
+   and type 'a Arg.t = 'a Functoria_key.Arg.t
+   and type Arg.info = Functoria_key.Arg.info
+   and type 'a value = 'a Functoria_key.value
+   and type 'a key = 'a Functoria_key.key
+   and type t = Functoria_key.t
+   and type Set.t = Functoria_key.Set.t
+   and type 'a Alias.t = 'a Functoria_key.Alias.t
+   and type context = Functoria_key.context

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -95,7 +95,18 @@ val match_impl: 'b value -> default:'a impl -> ('b * 'a impl) list ->  'a impl
     [cases] by matching the [v]'s value. [default] is chosen if no
     value matches. *)
 
-module type KEY = module type of struct include Functoria_key end
+
+module type KEY =
+  module type of Functoria_key
+  with type 'a Arg.converter = 'a Functoria_key.Arg.converter
+   and type 'a Arg.t = 'a Functoria_key.Arg.t
+   and type Arg.info = Functoria_key.Arg.info
+   and type 'a value = 'a Functoria_key.value
+   and type 'a key = 'a Functoria_key.key
+   and type t = Functoria_key.t
+   and type Set.t = Functoria_key.Set.t
+   and type 'a Alias.t = 'a Functoria_key.Alias.t
+   and type context = Functoria_key.context
 (** The signature for run-time and configure-time command-line
     keys. *)
 


### PR DESCRIPTION
The semantics of `module type of struct include X end` was changed by @lpw25 in 4.07. It now produces module aliases instead of expanding to the inner types. Since we use this signature to extend the modules in `Mirage`, it doesn't work anymore. This version manually expand all the type equalities.

This means that if we were to add a new types in `Functoria_key`, we need to add the equality here. If you think it's madness, I don't disagree. Hopefully we will have a better solution in 4.08.

This change should be fully backward compatible and can be used in any OCaml version.

In conjunction with https://github.com/mirage/mirage/pull/912, Fixes https://github.com/mirage/mirage/issues/911