### PR TITLE
Add Functoria_key.add_to_context

### DIFF
--- a/lib/functoria_key.ml
+++ b/lib/functoria_key.ml
@@ -262,6 +262,7 @@ let filter_stage stage s = match stage with
 type context = Univ.t
 let empty_context = Univ.empty
 let merge_context = Univ.merge
+let add_to_context t = Univ.add t.key
 
 let get (type a) ctx (t : a key) : a =
   match t.arg.Arg.kind, Univ.find t.key ctx with

--- a/lib/functoria_key.mli
+++ b/lib/functoria_key.mli
@@ -255,6 +255,9 @@ val empty_context : context
 
 val merge_context : default:context -> context -> context
 
+(** Add a binding to a context. *)
+val add_to_context : 'a key -> 'a -> context -> context
+
 val context:
   ?stage:Arg.stage -> with_required: bool ->
   Set.t -> context Cmdliner.Term.t


### PR DESCRIPTION
The `context` type is a bit difficult to manipulate in tests because the only way to build it is through `Cmdliner`.

This adds an `add` function which can extend an existing context. Together with `empty_context`, it makes it possible to build arbitrary contexts.