### PR TITLE
functoria_app: app_info fix callout to opam list --installed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v2.2.4 (2019-05-27)
+
+* fix app_info - executing "opam list --installed" (#170, by @hannesm)
+
 ## 2.2.3 (21/11/2018)
 
 * fix support for pin-depends (#165, by @hannesm)

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -151,9 +151,10 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
 
     method !build i =
       Log.info (fun m -> m "Generating: %a" Fpath.pp file);
-      let cmd = Bos.Cmd.(v "opam" % "list" % "--installed" % "-s" % "--rec" % "--depopts" % "--required-by" %% of_list (Info.libraries i)) in
+      let direct = String.concat ~sep:"," (Info.package_names i) in
+      let cmd = Bos.Cmd.(v "opam" % "list" % "--installed" % "-s" % "--rec" % "--depopts" % "--required-by" % direct) in
       (Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.out_lines) >>= fun (rdeps, _) ->
-      let opam = String.Set.(union (of_list (Info.package_names i)) (of_list rdeps)) in
+      let opam = String.Set.of_list rdeps in
       let ocl = String.Set.of_list (Info.libraries i)
       in
       Bos.OS.File.writef Fpath.(file + "in")


### PR DESCRIPTION
when I initially wrote the code, the logic was slightly different. then I tried to rebase on opam2 and didn't properly test the code it seems.

the result with functoria 2.2.3 is that `rdeps` is always empty since `opam list ...` expects comma-separated package names (rather than a list of packages). it is also the case that `opam list ...` returns the given packages --> no need to union `packages` with `rdeps`. and furthermore, `opam` likes packages, not ocamlfind-libraries+sublibraries.

TL;DR: this fixes `app_info` to output the whole set (including depopts and build only dependencies) of used packages, which is an overapproximation (but IMHO better than an underapproximation). I've tested this code with several unikernels, it works nicely for me.

there's some struggle with functoria, since it current master has #167 merged which is not yet ready for being released AFAIU, this patch is against 2.2.3 (I'd hope once we dune build, we'll be able to generate a more precise manifest of used packages, and don't need to call out to opam twice (`list` and `subst`)). my suggestion is, if people are happy with this PR, to create a 2.2 branch, push this change on that, and release functoria 2.2.4.