### PR TITLE
Invoke "opam list" with --color=never

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -152,7 +152,7 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
     method !build i =
       Log.info (fun m -> m "Generating: %a" Fpath.pp file);
       let direct = String.concat ~sep:"," (Info.package_names i) in
-      let cmd = Bos.Cmd.(v "opam" % "list" % "--installed" % "-s" % "--rec" % "--depopts" % "--required-by" % direct) in
+      let cmd = Bos.Cmd.(v "opam" % "list" % "--installed" % "-s" % "--rec" % "--color=never" % "--depopts" % "--required-by" % direct) in
       (Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.out_lines) >>= fun (rdeps, _) ->
       let opam = String.Set.of_list rdeps in
       let ocl = String.Set.of_list (Info.libraries i)


### PR DESCRIPTION
This is a fix for a problem with color and undeline escape sequences in the output of `opam list`.