### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "cmdliner" {>= "0.9.8"}
   "fmt"
   "functoria" {with-test & >= "2.2.0"}

--- a/functoria.opam
+++ b/functoria.opam
@@ -20,7 +20,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "base-unix"
   "cmdliner" {>= "0.9.8"}
   "rresult"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.