### PR TITLE
use different exit codes in argv parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - PINS="functoria.dev:. functoria-runtime.dev:."
+  - PINS="functoria.2.2.99:. functoria-runtime.2.2.99:."
   - REVDEPS=true
   matrix:
   - OCAML_VERSION=4.04 PACKAGE="functoria"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v2.2.5 (2019-10-14)
+
+* Functoria_runtime.with_argv now uses (#179, by @hannesm)
+  - exit 63 when `Help or `Version is requested (used to exit with 0)
+  - exit 64 when Term.eval returns with an error (used to raise an exception)
+
 ## v2.2.4 (2019-05-27)
 
 * fix app_info - executing "opam list --installed" (#170, by @hannesm)

--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -21,11 +21,12 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "cmdliner" {>= "0.9.8"}
   "fmt"
   "functoria" {with-test & >= "2.2.0"}
   "alcotest"  {with-test}
+  "dune" {with-test & <= "1.5.1"}
 ]
 
 synopsis: "Runtime support library for functoria-generated code"

--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -24,7 +24,7 @@ depends: [
   "dune"
   "cmdliner" {>= "0.9.8"}
   "fmt"
-  "functoria" {with-test & >= "2.2.0"}
+  "functoria" {with-test & >= "2.2.0" & < "3.0.0"}
   "alcotest"  {with-test}
   "dune" {with-test & <= "1.5.1"}
 ]

--- a/functoria.opam
+++ b/functoria.opam
@@ -20,7 +20,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "base-unix"
   "cmdliner" {>= "0.9.8"}
   "rresult"

--- a/runtime/functoria_runtime.ml
+++ b/runtime/functoria_runtime.ml
@@ -80,5 +80,5 @@ let with_argv keys s argv =
     let t = List.fold_right gather keys (Term.pure ()) in
     match Term.(eval ~argv (t, info s)) with
     | `Ok _ -> initialized := true; ()
-    | `Error _ -> failwith "Key initialization failed"
-    | `Help | `Version -> exit 0
+    | `Error _ -> exit 64
+    | `Help | `Version -> exit 63

--- a/runtime/functoria_runtime.mli
+++ b/runtime/functoria_runtime.mli
@@ -73,6 +73,8 @@ module Key: sig
 
 end
 
-(** [with_argv keys name argv] evaluates the [keys] {{!Key.term}terms}
-    on the command-line [argv]. [name] is the executable name. *)
+(** [with_argv keys name argv] evaluates the [keys] {{!Key.term}terms} on the
+    command-line [argv]. [name] is the executable name. On evaluation error the
+    application calls [exit(3)] with status [64].  If [`Help] or [`Version] were
+    evaluated, [exit(3)] is called with status [63]. *)
 val with_argv : unit Cmdliner.Term.t list -> string -> string array -> unit


### PR DESCRIPTION
`Functoria_runtime.with_argv` is parsing the argument vector. This is used by all MirageOS unikernels. It has a three-valued return: success (returns unit), `` `Help | `Version `` - used to be 0), Error (exception, OCaml runtime returns 2).

As it looks now when we start `hello` with an argument it cannot handle (`--fpoo=bar`):
```
console data 2019-10-11T23:18:42-00:00: hello: unknown option `--fpoo'.
console data 2019-10-11T23:18:42-00:00: Usage: hello [OPTION]... 
console data 2019-10-11T23:18:42-00:00: Try `hello --help' for more information.
console data 2019-10-11T23:18:42-00:00: Fatal error: exception Failure("Key initialization failed")
console data 2019-10-11T23:18:42-00:00: Raised at file "stdlib.ml", line 29, characters 17-33
console data 2019-10-11T23:18:42-00:00: Called from file "main.ml", line 29, characters 9-95
console data 2019-10-11T23:18:42-00:00: Called from file "camlinternalLazy.ml", line 31, characters 17-27
console data 2019-10-11T23:18:42-00:00: Re-raised at file "camlinternalLazy.ml", line 36, characters 4-11
console data 2019-10-11T23:18:42-00:00: Solo5: solo5_exit(2) called
```

Now, I intended to implement a restart-on-failure feature in [albatross](https://github.com/hannesm/albatross). The only information we have at exit is the exit code, and this can be divided into "those which should trigger a restart" (i.e. out of memory in most unikernels, unhandled exception, ..) and "those which should _not_ trigger a restart" (i.e. solo5 tender can't process spt/hvt image, manifest mismatch, boot argument parser error).

FWIW, I figured the following exit codes are used:
- solo5 returns whatever exit code the guest passed to `void exit(int status)`.
- 0 normal termination
- 1 solo5 internal failure (i.e. bad image / mismatch between manifest and command line arguments)
- 2 unhandled OCaml exception (out of memory, ...) -- to be changed to `abort()` in 4.10.0, see https://github.com/ocaml/ocaml/pull/8630
- 255 `solo5_abort`

Now, while restart-on-failure can be configured by a user with a whitelist of exit code which should trigger a restart, there is need for a sensible default, which is everything besides `1` and the (arbitrary) range `64..70`.

(this is a PR against 2.2 which I tested locally, if this is accepted I'll of course PR as well against master)