### PR TITLE
remove custom opam version comparison which is inconsistent with opam, fix #149

### DIFF
--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -41,7 +41,7 @@ module Package = struct
       | None, Some a | Some a, None -> Some a
       | Some a, Some b when String.equal a b -> Some a
       | _ -> invalid_arg ("conflicting pin depends for " ^ opam)
-    and build = if not a.build || not b.build then false else true
+    and build = a.build || b.build
     in
     match pin with
     | Some _ ->

--- a/lib/functoria.mli
+++ b/lib/functoria.mli
@@ -122,8 +122,8 @@ type package = private {
   pin : string option ;
   build : bool ;
   ocamlfind : Astring.String.Set.t ;
-  min : string option ;
-  max : string option
+  min : Astring.String.Set.t ;
+  max : Astring.String.Set.t ;
 }
 (** The type of a package *)
 


### PR DESCRIPTION
instead of merging min and max constraints, collect them in a set and output
 all of them, leaving the merge to opam

i.e. consider the collected bounds:
- package ~min:"1.0" ~max:"2.0" "a"
- package ~min:"1.2" ~max:"3.0" "a"
- package ~min:"1.5" ~max:"2.0" "a"

it used to merge them, and produce
 "a" {>= "1.5" & < "2.0"}

now, it'll output
 "a" {>= "1.0" & >= "1.2" & >= "1.5" & < "2.0" & < "3.0"}

the previous approach failed on various version identifiers that are valid in
opam, such as "v1.0", "1.2.3-99", "2.0~beta" -- since the functoria version
parser only allowed dot "." and numbers.