### PR TITLE
dune exec only a single job

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -664,6 +664,7 @@ module Make (P: S) = struct
     let target_dir = relativize ~root:project_root build_dir in
     let command =
       Bos.Cmd.(v "dune" % "exec"
+               % "-j" % "1" (* run sequentially, see #187 *)
                % "--root" % p project_root
                % "--" % p Fpath.(target_dir / "config.exe") %% args)
     in


### PR DESCRIPTION
The observed issue (in CI https://travis-ci.org/mirage/mirage-nat/jobs/607896490?utm_medium=notification&utm_source=github_status and locally)
```
File "unikernel.ml", line 74, characters 27-47:
Error: Unbound value Key_gen.private_ipv4
```

Another observation is in [this PR](https://github.com/roburio/openvpn/pull/6) where CI ran twice (push and pr) with diverging output:
- failure (qubes build) https://travis-ci.org/roburio/openvpn/builds/616130870?utm_source=github_status&utm_medium=notification
- success https://travis-ci.org/roburio/openvpn/builds/616130861?utm_source=github_status&utm_medium=notification

Now, this is the same code in the CI runs (and same installed libraries), thus there must be a race condition somewhere (in this examples, it is calling `create_ipv4` twice with different `~group` parameters). I managed to reproduce this locally, sometimes with the Unix target, other times with the qubes target).

After reading the `_build/log`, the configuration phase inferred two jobs. With the change in this PR, I cannot reproduce the race condition (and thus would like this to be merged -- I'm happy/open if someone else investigates where/when concurrency is an issue for functoria, but it won't be me). FWIW, cloning the mirage-nat repository, using the `easy` branch from hannesm/mirage-nat, and running `mirage clean ; mirage configure -vv && grep ipv4\  key_gen.ml` in a tight loop, erroring if grep only finds two lines (i.e. the private_ipv4 is missing), a good outcome is grep finding 4 lines.

thanks for reading so far. /cc @mirage/core @TheLortex @samoht 