### PR TITLE
Fix equality for 'a impl values

### DIFF
--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -256,6 +256,7 @@ let rec equal
   = fun x y -> match x, y with
     | Impl c, Impl c' ->
       c#name = c'#name
+      && List.for_all2 Key.equal c#keys c'#keys
       && List.for_all2 equal_any c#deps c'#deps
     | App a, App b -> equal a.f b.f && equal a.x b.x
     | If (cond1, t1, e1), If (cond2, t2, e2) ->

--- a/lib/functoria_key.ml
+++ b/lib/functoria_key.ml
@@ -211,6 +211,7 @@ end
 
 type t = Set.elt = Any: 'a key -> t
 let compare = Set.M.compare
+let equal (Any x) (Any y) = String.equal x.name y.name
 
 module Alias = struct
 

--- a/lib/functoria_key.mli
+++ b/lib/functoria_key.mli
@@ -182,6 +182,9 @@ end
 val abstract: 'a key -> t
 (** [hide k] is the [k] with its type hidden. *)
 
+val equal : t -> t -> bool
+(** [equa] is the equality function of untyped keys. *)
+
 val compare: t -> t -> int
 (** [compare] compares untyped keys. *)
 


### PR DESCRIPTION
This fixes random issues with `mirage configure` when multiple keys
sharing the same name. Replaces #187