### PR TITLE
Do not compile config.ml with -warn-error by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v3.1.0 (2020-03-09)
+
+* Always use `-warn-error -A` when compiling `config.ml`. This allows
+  to use deprecated devices without failing (#193, @samoht)
+
 ## v3.0.3 (2019-12-17)
 
 * Fix equality for `'a impl` values, which caused issue in `mirage configure`

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -619,6 +619,7 @@ module Make (P: S) = struct
 
 %a(executable
   (name config)
+  (flags (:standard -warn-error -A))
   (modules %s)
   (libraries %s))
 |}


### PR DESCRIPTION
A tentative fix for https://github.com/mirage/functoria/issues/182

Both functoria and mirage are defining the same flag, so I'm not sure if this will work very well without a patch to mirage too (or we will have to rename that flag).