### PR TITLE
If `config_file` is changed, update the dune.config

### DIFF
--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -618,13 +618,13 @@ module Make (P: S) = struct
         {|%s
 
 %a(executable
-  (name config)
+  (name %s)
   (flags (:standard -warn-error -A))
   (modules %s)
   (libraries %s))
 |}
         auto_generated Fmt.(list ~sep:(unit "") string) copy_rules
-        config_file pkgs
+        config_file config_file pkgs
     in
     generate ~file ~contents
 
@@ -682,10 +682,11 @@ module Make (P: S) = struct
     >>= fun () ->
     let args = Bos.Cmd.of_list (List.tl (Array.to_list argv)) in
     let target_dir = relativize ~root:project_root build_dir in
+    let config_exe = Fpath.(basename (rem_ext config_file)) ^ ".exe" in
     let command =
       Bos.Cmd.(v "dune" % "exec"
                % "--root" % p project_root
-               % "--" % p Fpath.(target_dir / "config.exe") %% args)
+               % "--" % p Fpath.(target_dir / config_exe) %% args)
     in
     match help_ppf, err_ppf with
     | None, None -> Bos.OS.Cmd.run command


### PR DESCRIPTION
For example
```
$ cd mirage-skeleton/tutorial/noop
$ mv config.ml config_test.ml
$ mirage configure -f config_test.ml
```
Previously I would see:
```
File "dune.config", line 5, characters 8-14:
5 |   (name config)
            ^^^^^^
Error: Module "Config" doesn't exist.
run ['dune' 'exec' '--root' '/home/djs/djs55/mirage-skeleton/tutorial/noop'
     '--' './config.exe' 'configure' '-f' 'config_test.ml']: exited with 1
```
The `dune.config` file has:
```
;; auto-generated by 'mirage configure -- remove these comments to
;; preserve the file after a `mirage clean`

(executable
  (name config)
  (flags (:standard -warn-error -A))
  (modules config_test)
  (libraries mirage))
```

I think we need to update the `name` (and the final .exe) if the `config_file` is changed.

Signed-off-by: David Scott <dave@recoil.org>