### PR TITLE
Fix warnings on OCaml 4.12

### DIFF
--- a/runtime/functoria_runtime.ml
+++ b/runtime/functoria_runtime.ml
@@ -33,7 +33,7 @@ module Arg = struct
     | None -> required c i
     | Some d -> opt c d i
 
-  let default (type a) (t : a t) = match t.kind with
+  let default (type a) (t : a t) : a option = match t.kind with
     | Opt (d,_) -> Some d
     | Flag -> Some false
     | Required _ -> None


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/9811 introduced a new warning to the compiler which is triggered by `functoria`:
```
File "runtime/functoria_runtime.ml", lines 36-39, characters 35-24:
36 | ...................................match t.kind with
37 |     | Opt (d,_) -> Some d
38 |     | Flag -> Some false
39 |     | Required _ -> None
Warning 18 [not-principal]: 
  The return type of this pattern-matching is ambiguous.
  Please add a type annotation, as the choice of `a option' is not principal.
```