### PR TITLE
Fixes for cmdliner and fmt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,10 @@
-## v3.1.1 (20120-06-10)
+## v3.1.2 (2022-03-07)
+
+* Support cmdliner 1.1.0, alcotest 1.4.0 and avoid fmt 0.8.7 deprecations
+  (#201 @hannesm)
+* Disable deprecation alerts in dune files to allow CI to pass (#201 @hannesm)
+
+## v3.1.1 (2020-06-10)
 
 * Ensure that keys with different defaults are distinguished by functoria.
   `Functoria.Key.equal` has been introduced in #188 but it was not precise

--- a/app/dune
+++ b/app/dune
@@ -3,4 +3,5 @@
  (public_name functoria.app)
  (libraries functoria dynlink cmdliner rresult fmt.tty fmt.cli ocamlgraph astring fpath bos logs logs.cli logs.fmt)
  (wrapped false)
+ (flags (:standard (-w -3)))
 )

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -414,14 +414,13 @@ end
     Currently, we cache Sys.argv directly
 *)
 module Cache : sig
-  open Cmdliner
   val save : argv:string array -> Fpath.t -> (unit, [> Rresult.R.msg ]) result
   val clean : Fpath.t -> (unit, [> Rresult.R.msg ]) result
-  val get_context : Fpath.t -> context Term.t ->
+  val get_context : Fpath.t -> context Cmdliner.Term.t ->
     [> `Error of bool * string | `Ok of context option ]
   val get_output: Fpath.t -> [> `Error of bool * string | `Ok of string option ]
-  val require :
-    [< `Error of bool * string | `Ok of context option ] -> context Term.ret
+  val require : [< `Error of bool * string | `Ok of context option ] ->
+    context Cmdliner.Term.ret
   val merge :
     cache:[< `Error of bool * string | `Ok of context option ] ->
     context -> context
@@ -707,17 +706,16 @@ module Make (P: S) = struct
       exit 1
 
   let handle_parse_args_no_config ?help_ppf ?err_ppf error argv =
-    let open Cmdliner in
     let base_keys = Config.extract_keys (P.create []) in
     let base_context =
       Key.context base_keys ~with_required:false ~stage:`Configure
     in
     let result =
       Cmd.parse_args ?help_ppf ?err_ppf ~name:P.name ~version:P.version
-        ~configure:(Term.pure ())
-        ~describe:(Term.pure ())
-        ~build:(Term.pure ())
-        ~clean:(Term.pure ())
+        ~configure:(Cmdliner.Term.pure ())
+        ~describe:(Cmdliner.Term.pure ())
+        ~build:(Cmdliner.Term.pure ())
+        ~clean:(Cmdliner.Term.pure ())
         ~help:base_context
         argv
     in

--- a/app/functoria_app.ml
+++ b/app/functoria_app.ml
@@ -104,7 +104,7 @@ let keys (argv: argv impl) = impl @@ object
     method !deps = [ abstract argv ]
     method !connect info modname = function
       | [ argv ] ->
-        Fmt.strf
+        Fmt.str
           "return (Functoria_runtime.with_argv (List.map fst %s.runtime_keys) %S %s)"
           modname (Info.name info) argv
       | _ -> failwith "The keys connect should receive exactly one argument."
@@ -117,11 +117,11 @@ let info = Type Info
 
 let pp_libraries fmt l =
   Fmt.pf fmt "[@ %a]"
-    Fmt.(iter ~sep:(unit ";@ ") List.iter @@ fmt "%S") l
+    Fmt.(iter ~sep:(any ";@ ") List.iter @@ fmt "%S") l
 
 let pp_packages fmt l =
   Fmt.pf fmt "[@ %a]"
-    Fmt.(iter ~sep:(unit ";@ ") List.iter @@
+    Fmt.(iter ~sep:(any ";@ ") List.iter @@
          (fun fmt x -> pf fmt "%S, \"%%{%s:version}%%\"" x x)
         ) l
 
@@ -141,7 +141,7 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
     val file = Fpath.(v (String.Ascii.lowercase gen_modname) + "ml")
     method module_name = gen_modname
     method !packages = Key.pure [package "functoria-runtime"]
-    method !connect _ modname _ = Fmt.strf "return %s.info" modname
+    method !connect _ modname _ = Fmt.str "return %s.info" modname
 
     method !clean _i =
       Bos.OS.Path.delete file >>= fun () ->
@@ -160,8 +160,8 @@ let app_info ?(type_modname="Functoria_info")  ?(gen_modname="Info_gen") () =
         Log.debug (fun m -> m
                       "opam_deps %d args %d collected\nargs: %a\ncollected: %a"
                       (String.Set.cardinal args) (String.Set.cardinal collected)
-                      (String.Set.pp ~sep:(Fmt.unit ",") Fmt.string) args
-                      (String.Set.pp ~sep:(Fmt.unit ",") Fmt.string) collected);
+                      (String.Set.pp ~sep:(Fmt.any ",") Fmt.string) args
+                      (String.Set.pp ~sep:(Fmt.any ",") Fmt.string) collected);
         if String.Set.is_empty args then Ok collected
         else
           let pkgs = String.concat ~sep:"," (String.Set.elements args) in
@@ -212,7 +212,7 @@ module Engine = struct
      module construction. *)
   let name c id =
     let prefix = Name.ocamlify c#name in
-    Name.create (Fmt.strf "%s%i" prefix id) ~prefix
+    Name.create (Fmt.str "%s%i" prefix id) ~prefix
 
   (* [module_expresion tbl c args] returns the module expression of
      the functor [c] applies to [args]. *)
@@ -234,7 +234,7 @@ module Engine = struct
         | None -> base
       in
       let prefix = Name.ocamlify prefix in
-      Name.create (Fmt.strf "%s%i" prefix id) ~prefix
+      Name.create (Fmt.str "%s%i" prefix id) ~prefix
 
   (* FIXME: Can we do better than lookup by name? *)
   let find_device info g impl =
@@ -607,13 +607,13 @@ module Make (P: S) = struct
         let root = Fpath.(project_root // root) in
         let src = relativize ~root file in
         let file = Fpath.basename file in
-        Fmt.strf "(rule (copy %a %s))\n\n" Fpath.pp src file
+        Fmt.str "(rule (copy %a %s))\n\n" Fpath.pp src file
     in
     list_files Fpath.(project_root // source_dir) >>= fun files ->
     let copy_rules = List.map copy_rule files in
     let config_file = Fpath.(basename (rem_ext !config_file)) in
     let contents =
-      Fmt.strf
+      Fmt.str
         {|%s
 
 %a(executable
@@ -622,7 +622,7 @@ module Make (P: S) = struct
   (modules %s)
   (libraries %s))
 |}
-        auto_generated Fmt.(list ~sep:(unit "") string) copy_rules
+        auto_generated Fmt.(list ~sep:(any "") string) copy_rules
         config_file pkgs
     in
     generate ~file ~contents
@@ -637,7 +637,7 @@ module Make (P: S) = struct
   let generate_dune () =
     let file = Fpath.v "dune" in
     let contents =
-      Fmt.strf "%s
+      Fmt.str "%s
 
 (include dune.config)\n\n(include dune.build)\n"
         auto_generated
@@ -647,7 +647,7 @@ module Make (P: S) = struct
   (* Generate a `dune-project` file at the project root. *)
   let generate_dune_project ~project_root =
     let file = Fpath.(project_root / "dune-project") in
-    let contents = Fmt.strf "(lang dune 1.1)\n%s\n" auto_generated in
+    let contents = Fmt.str "(lang dune 1.1)\n%s\n" auto_generated in
     generate ~file ~contents
 
   (* Generate the configuration files in the the build directory *)

--- a/app/functoria_graph.ml
+++ b/app/functoria_graph.ml
@@ -422,13 +422,13 @@ module Dot = Graphviz.Dot(struct
     let vertex_attributes v = match V.label v with
       | App -> [ `Label "$"; `Shape `Diamond ]
       | If cond ->
-        [ `Label (Fmt.strf "If\n%a" Key.pp_deps cond) ]
+        [ `Label (Fmt.str "If\n%a" Key.pp_deps cond) ]
       | Impl f ->
         let label =
-          Fmt.strf
+          Fmt.str
             "%s\n%s\n%a"
             f#name f#module_name
-            Fmt.(list ~sep:(unit ", ") Key.pp)
+            Fmt.(list ~sep:(any ", ") Key.pp)
             f#keys
         in
         [ `Label label; `Shape `Box; ]

--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -20,11 +20,10 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
   "cmdliner" {>= "0.9.8"}
-  "fmt"
-  "functoria" {with-test & >= "2.2.0"}
+  "functoria" {with-test & = version}
   "alcotest"  {with-test}
 ]
 

--- a/functoria.opam
+++ b/functoria.opam
@@ -19,13 +19,12 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
-  "base-unix"
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "1.1.0"}
   "rresult"
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "ocamlgraph"
   "logs"
   "bos"

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,5 @@
  (public_name functoria)
  (libraries unix cmdliner rresult fmt astring fpath ptime.clock.os)
  (wrapped false)
+ (flags (:standard (-w -3)))
 )

--- a/lib/functoria.ml
+++ b/lib/functoria.ml
@@ -136,7 +136,7 @@ module Info = struct
 
   let pp verbose ppf ({ name ; build_dir ; keys ; context ; output; _ } as t) =
     let show name = Fmt.pf ppf "@[<2>%s@ %a@]@," name in
-    let list = Fmt.iter ~sep:(Fmt.unit ",@ ") List.iter Fmt.string in
+    let list = Fmt.iter ~sep:(Fmt.any ",@ ") List.iter Fmt.string in
     show "Name      " Fmt.string name;
     show "Build-dir " Fpath.pp build_dir;
     show "Keys      " (Key.pps context) keys;
@@ -144,14 +144,14 @@ module Info = struct
     if verbose then show "Libraries " list (libraries t);
     if verbose then
       show "Packages  "
-        (pp_packages ?surround:None ~sep:(Fmt.unit ",@ ")) t
+        (pp_packages ?surround:None ~sep:(Fmt.any ",@ ")) t
 
   let opam ?name ppf t =
     let name = match name with None -> t.name | Some x -> x in
     Fmt.pf ppf "opam-version: \"2.0\"@." ;
     Fmt.pf ppf "name: \"%s\"@." name ;
     Fmt.pf ppf "depends: [ @[<hv>%a@]@ ]@."
-      (pp_packages ~surround:"\"" ~sep:(Fmt.unit "@ ")) t ;
+      (pp_packages ~surround:"\"" ~sep:(Fmt.any "@ ")) t ;
     match pins t with
     | [] -> ()
     | pin_depends ->
@@ -159,7 +159,7 @@ module Info = struct
         Fmt.pf ppf "[\"%s.dev\" %S]" package url
       in
       Fmt.pf ppf "pin-depends: [ @[<hv>%a@]@ ]@."
-        Fmt.(list ~sep:(unit "@ ") pp_pin) pin_depends
+        Fmt.(list ~sep:(any "@ ") pp_pin) pin_depends
 end
 
 type _ typ =
@@ -236,7 +236,7 @@ class ['ty] foreign
     method keys = keys
     method packages = Key.pure packages
     method connect _ modname args =
-      Fmt.strf
+      Fmt.str
         "@[%s.start@ %a@]"
         modname
         Fmt.(list ~sep:sp string)  args

--- a/lib/functoria_key.ml
+++ b/lib/functoria_key.ml
@@ -55,12 +55,12 @@ module Arg = struct
 
   let list d = conv
       ~conv:(Cmdliner.Arg.list (converter d))
-      ~runtime_conv:(Fmt.strf "(Cmdliner.Arg.list %s)" (runtime_conv d))
+      ~runtime_conv:(Fmt.str "(Cmdliner.Arg.list %s)" (runtime_conv d))
       ~serialize:(Serialize.list (serialize d))
 
   let some d = conv
       ~conv:(Cmdliner.Arg.some (converter d))
-      ~runtime_conv:(Fmt.strf "(Cmdliner.Arg.some %s)" (runtime_conv d))
+      ~runtime_conv:(Fmt.str "(Cmdliner.Arg.some %s)" (runtime_conv d))
       ~serialize:(Serialize.option (serialize d))
 
   (** {1 Information about arguments} *)
@@ -170,7 +170,7 @@ module Arg = struct
 
   let make_opt_cmdliner wrap i default f desc =
     let none = match default with
-      | Some d -> Some (Fmt.strf "%a" (pp_conv desc) d)
+      | Some d -> Some (Fmt.str "%a" (pp_conv desc) d)
       | None -> None
     in
     let f_desc v z = match v with
@@ -280,7 +280,7 @@ module Set = struct
     else
       add k set
 
-  let pp = Fmt.iter ~sep:(Fmt.unit ",@ ") iter
+  let pp = Fmt.iter ~sep:(Fmt.any ",@ ") iter
 
 end
 
@@ -379,7 +379,7 @@ let pp_deps fmt v = Set.pp pp fmt v.deps
 
 let pps p =
   let pp' fmt k v =
-    let default = if mem_u p k then Fmt.nop else Fmt.unit " (default)" in
+    let default = if mem_u p k then Fmt.nop else Fmt.any " (default)" in
     Fmt.pf fmt "%a=%a%a"
       Fmt.(styled `Bold string) k.name
       (Arg.pp k.arg) v
@@ -402,9 +402,9 @@ let info_alias setters =
   match setters with
   | [] -> ""
   | [ _ ] ->
-    Fmt.strf "Will automatically set %a." (Set.pp f) (Alias.keys setters)
+    Fmt.str "Will automatically set %a." (Set.pp f) (Alias.keys setters)
   | _ ->
-    Fmt.strf "Will automatically set the following keys: %a."
+    Fmt.str "Will automatically set the following keys: %a."
       (Set.pp f) (Alias.keys setters)
 
 let info_arg (type a) (arg: a Arg.kind) = match arg with

--- a/lib/functoria_misc.ml
+++ b/lib/functoria_misc.ml
@@ -132,6 +132,6 @@ module Univ = struct
   let dump =
     let pp_elt ppf (k, v) = Fmt.pf ppf "%s: %a@ " k Fmt.exn v in
     let map_iter f = Map.iter (fun k v -> f (k, v)) in
-    Fmt.(iter ~sep:(unit ", ")) map_iter pp_elt
+    Fmt.(iter ~sep:(any ", ")) map_iter pp_elt
 
 end

--- a/runtime/dune
+++ b/runtime/dune
@@ -1,6 +1,7 @@
 (library
  (name functoria_runtime)
  (public_name functoria-runtime)
- (libraries bytes cmdliner fmt)
+ (libraries cmdliner)
  (wrapped false)
+ (flags (:standard (-w -3)))
 )

--- a/tests/dune
+++ b/tests/dune
@@ -3,9 +3,11 @@
  (modules   test_core)
  (libraries test_app alcotest cmdliner rresult astring)
  (package   functoria)
- (deps      app/config.ml app/app.ml))
+ (deps      app/config.ml app/app.ml)
+ (flags (:standard (-w -3))))
 
 (executable
  (name      test_full)
  (modules   test_full)
- (libraries functoria.test alcotest cmdliner rresult astring))
+ (libraries functoria.test alcotest cmdliner rresult astring)
+ (flags (:standard (-w -3))))

--- a/tests/lib/test_app.ml
+++ b/tests/lib/test_app.ml
@@ -75,7 +75,7 @@ module C = struct
         ]
 
       method! configure i =
-        let dune = Fmt.strf
+        let dune = Fmt.str
             "(executable\n\
             \   (name      %s)\n\
             \   (modules (:standard \\ config))\n\

--- a/tests/test_full.ml
+++ b/tests/test_full.ml
@@ -20,7 +20,7 @@ module Cmd = Functoria_command_line
 let list_files dir =
   let l = Bos.OS.Path.matches ~dotfiles:true Fpath.(dir / "$(file)") in
   match l with
-  | Error (`Msg e) -> Fmt.kstrf Alcotest.fail "list_files: %s" e
+  | Error (`Msg e) -> Fmt.kstr (fun s -> Alcotest.fail s) "list_files: %s" e
   | Ok l ->
     List.sort String.compare @@
     List.rev_map (fun x ->
@@ -58,7 +58,7 @@ let clean_build () =
   get_ok @@ Bos.OS.Dir.delete ~recurse:true dir
 
 let test ?err_ppf ?help_ppf fmt =
-  Fmt.kstrf (fun l ->
+  Fmt.kstr (fun l ->
       let l = String.cuts ~sep:" " l in
       Test_app.run_with_argv ?err_ppf ?help_ppf (Array.of_list ("" :: l))
     ) fmt


### PR DESCRIPTION
This PR fixes compatibility for cmdliner 1.1.0 and fmt. It does not require cmdliner >= 1.1.0, so we can use functoria with earlier cmdliner versions. The reason for this change (though mirage4 uses functoria from the mirage repository) is to allow mirage3 to continue even if our ecosystem upgrade to cmdliner >= 1.1.0. The fmt stuff is only stylistic.